### PR TITLE
When it's a background menu, hide the "propertries" action in the menu 

### DIFF
--- a/peony-qt-desktop/desktop-menu.cpp
+++ b/peony-qt-desktop/desktop-menu.cpp
@@ -86,7 +86,11 @@ void DesktopMenu::fillActions()
         addSeparator();
 
     //add propertries actions
-    auto propertiesAction = constructFilePropertiesActions();
+    //if this is a backgroud menu, then it should not add propertries actions
+    bool isBackgroundMenu = m_selections.isEmpty();
+    if(!isBackgroundMenu) {
+        auto propertiesAction = constructFilePropertiesActions();
+    }
 }
 
 const QList<QAction *> DesktopMenu::constructOpenOpActions()


### PR DESCRIPTION
fix #14. Right click on the desktop,  when the menu is a background menu just don't add "propertries" action.