### PR TITLE
refresh Recycle Bin Icon after clean the trash

### DIFF
--- a/peony-qt-desktop/desktop-menu.cpp
+++ b/peony-qt-desktop/desktop-menu.cpp
@@ -376,6 +376,8 @@ const QList<QAction *> DesktopMenu::constructFileOpActions()
                 if (result == QMessageBox::Yes) {
                     FileEnumerator e;
                     FileOperationUtils::remove(trashChildren);
+                    auto desktopView = dynamic_cast<DesktopIconView*>(m_view);
+                    desktopView->refresh();
                 }
             });
             l.last()->setEnabled(!trashChildren.isEmpty());


### PR DESCRIPTION
After "Clean the trash" Action, the icon of Recycle Bin is not changed(#48). So I call DesktopIconView::refresh() function to fix it.