### PR TITLE
copy same file to desktop twice, error report dialog show twice

### DIFF
--- a/libpeony-qt/file-operation/file-operation-error-dialog.cpp
+++ b/libpeony-qt/file-operation/file-operation-error-dialog.cpp
@@ -37,7 +37,9 @@ FileOperationErrorDialog::FileOperationErrorDialog(QWidget *parent) : QDialog(pa
 {
     //center to desktop.
     setParent(QApplication::desktop());
-    setWindowFlag(Qt::Dialog);
+    //setWindowFlag(Qt::Dialog);
+    //use WindowStaysOnTopHint flag to make sure this dialog always stay on top
+    setWindowFlags(Qt::Dialog | Qt::WindowStaysOnTopHint);
     setWindowTitle(tr("File Operation Error"));
     setWindowIcon(QIcon::fromTheme("system-error"));
     m_layout = new QFormLayout(this);


### PR DESCRIPTION
Copy same file to desktop twice(#50), it should call FileOperationErrorDialog to show error info. but when FileOperationProgressWizard showed, it cause previous dialog flashed once.
Even though FileOperationErrorDialog only show once but it looks like this dialog have showed twice. We should use WindowStaysOnTopHint to make sure this dialog show on top to avoid this problem.