### PR TITLE
fix change file content and close file, file info is not update in list view

### DIFF
--- a/libpeony-qt/model/file-item.cpp
+++ b/libpeony-qt/model/file-item.cpp
@@ -354,6 +354,9 @@ void FileItem::onChildAdded(const QString &uri)
     FileItem *child = getChildFromUri(uri);
     if (child) {
         qDebug()<<"has added";
+        //child info maybe changed, so need sync update again
+        child->updateInfoSync();
+        m_model->updated();
         return;
     }
     FileItem *newChild = new FileItem(FileInfo::fromUri(uri), this, m_model);


### PR DESCRIPTION
when change file content and close file(#69). FileItem::onChildAdded was called. m_model may already have this child, but  the child info may be changeed. So child info need to update.