### PR TITLE
if click left button at blank space, it should select nothing

### DIFF
--- a/libpeony-qt/controls/directory-view/view/list-view/list-view.cpp
+++ b/libpeony-qt/controls/directory-view/view/list-view/list-view.cpp
@@ -115,6 +115,14 @@ void ListView::mousePressEvent(QMouseEvent *e)
         this->setState(QAbstractItemView::DragSelectingState);
     }
 
+    //if click left button at blank space, it should select nothing
+    if(e->button() == Qt::LeftButton && (!indexAt(e->pos()).isValid()) )
+    {
+        this->clearSelection();
+        this->clearFocus();
+        return;
+    }
+
     if (e->button() == Qt::LeftButton) {
         qDebug()<<m_edit_trigger_timer.isActive()<<m_edit_trigger_timer.interval();
         if (indexAt(e->pos()).row() == m_last_index.row() && m_last_index.isValid()) {
@@ -324,7 +332,10 @@ void ListView2::bindModel(FileItemModel *model, FileItemProxyFilterSortModel *pr
     connect(m_view, &ListView::customContextMenuRequested, this, [=](const QPoint &pos){
         qDebug()<<"menu request";
         if (!m_view->indexAt(pos).isValid())
+        {
             m_view->clearSelection();
+            m_view->clearFocus();
+        }
 
         auto index = m_view->indexAt(pos);
         auto selectedIndexes = m_view->selectionModel()->selection().indexes();
@@ -334,9 +345,11 @@ void ListView2::bindModel(FileItemModel *model, FileItemProxyFilterSortModel *pr
         if (!selectedIndexes.contains(index)) {
             if (!validRect.contains(pos)) {
                 m_view->clearSelection();
+                m_view->clearFocus();
             } else {
                 auto flags = QItemSelectionModel::Select|QItemSelectionModel::Rows;
                 m_view->clearSelection();
+                m_view->clearFocus();
                 m_view->selectionModel()->select(m_view->indexAt(pos), flags);
             }
         }


### PR DESCRIPTION
Add clearSelection() in the ListView::mousePressEvent() can slove this problem(#92).
And the reason why I add clearFocus() in ListView2::bindModel() is if I don't add this function then when I do this: 1.click an item; 2. click blank space; 3. click another item. The first item will be included in a dotted box while the menu pop up near the second item.