### PR TITLE
fix peony rename logic error

### DIFF
--- a/data/peony-computer.desktop
+++ b/data/peony-computer.desktop
@@ -1,0 +1,11 @@
+[Desktop Entry]
+Name=Peony Computer
+GenericName=Computer
+GenericName[zh_CN]=打开计算机
+Name[zh_CN]=计算机
+Exec=/usr/bin/peony computer:///
+MimeType=inode/directory
+Icon=computer
+Terminal=false
+Type=Application
+Keywords=file;home;folder;browser;disk;computer;

--- a/data/peony-home.desktop
+++ b/data/peony-home.desktop
@@ -1,0 +1,11 @@
+[Desktop Entry]
+Name=Peony Home
+GenericName=Home
+GenericName[zh_CN]=打开个人目录
+Name[zh_CN]=个人目录
+Exec=/usr/bin/peony
+MimeType=inode/directory
+Icon=user-home
+Terminal=false
+Type=Application
+Keywords=file;home;folder;browser;disk;computer;

--- a/data/peony-trash.desktop
+++ b/data/peony-trash.desktop
@@ -1,0 +1,11 @@
+[Desktop Entry]
+Name=Peony Trash
+GenericName=Trash
+GenericName[zh_CN]=打开回收站
+Name[zh_CN]=回收站
+Exec=/usr/bin/peony trash:///
+MimeType=inode/directory
+Icon=user-trash
+Terminal=false
+Type=Application
+Keywords=file;home;folder;browser;disk;computer;

--- a/debian/peony.install
+++ b/debian/peony.install
@@ -1,3 +1,6 @@
 usr/bin/*
 data/peony.desktop usr/share/applications
+data/peony-computer.desktop usr/share/applications
+data/peony-home.desktop usr/share/applications
+data/peony-trash.desktop usr/share/applications
 data/peony-desktop.desktop etc/xdg/autostart

--- a/libpeony-qt/controls/directory-view/delegate/icon-view-index-widget.cpp
+++ b/libpeony-qt/controls/directory-view/delegate/icon-view-index-widget.cpp
@@ -173,11 +173,12 @@ void IconViewIndexWidget::paintEvent(QPaintEvent *e)
 void IconViewIndexWidget::mousePressEvent(QMouseEvent *e)
 {
     if (e->button() == Qt::LeftButton) {
-        if (m_edit_trigger.isActive()) {
-            m_delegate->getView()->setIndexWidget(m_index, nullptr);
-            m_delegate->getView()->edit(m_index);
-            return;
-        }
+//        if (m_edit_trigger.isActive()) {
+//            qDebug()<<"IconViewIndexWidget::mousePressEvent: edit"<<e->type();
+//            m_delegate->getView()->setIndexWidget(m_index, nullptr);
+//            m_delegate->getView()->edit(m_index);
+//            return;
+//        }
     }
     QWidget::mousePressEvent(e);
 }

--- a/libpeony-qt/controls/directory-view/directory-view-container.cpp
+++ b/libpeony-qt/controls/directory-view/directory-view-container.cpp
@@ -364,6 +364,8 @@ Qt::SortOrder DirectoryViewContainer::getSortOrder()
 
 void DirectoryViewContainer::setSortOrder(Qt::SortOrder order)
 {
+    if (order < 0)
+        return;
     if (!m_view)
         return;
     m_view->setSortOrder(order);

--- a/libpeony-qt/controls/directory-view/directory-view-factory/directory-view-factory-manager.cpp
+++ b/libpeony-qt/controls/directory-view/directory-view-factory/directory-view-factory-manager.cpp
@@ -153,7 +153,7 @@ const QString DirectoryViewFactoryManager2::getDefaultViewId()
     if (m_default_view_id_cache.isNull()) {
         auto string = m_settings->value("directory-view/default-view-id").toString();
         if (string.isEmpty()) {
-            string = "Icon View";
+            string = IconViewFactory2::getInstance()->name();
         }
         m_default_view_id_cache = string;
     }

--- a/libpeony-qt/controls/directory-view/view/icon-view/icon-view-style.cpp
+++ b/libpeony-qt/controls/directory-view/view/icon-view/icon-view-style.cpp
@@ -50,6 +50,14 @@ void IconViewStyle::release()
         global_instance->deleteLater();
 }
 
+void IconViewStyle::drawPrimitive(QStyle::PrimitiveElement element, const QStyleOption *option, QPainter *painter, const QWidget *widget) const
+{
+    if (element == PE_Frame) {
+        return;
+    }
+    return QProxyStyle::drawPrimitive(element, option, painter, widget);
+}
+
 void IconViewStyle::drawControl(QStyle::ControlElement element, const QStyleOption *option, QPainter *painter, const QWidget *widget) const
 {
     if (element == QStyle::CE_RubberBand) {

--- a/libpeony-qt/controls/directory-view/view/icon-view/icon-view-style.h
+++ b/libpeony-qt/controls/directory-view/view/icon-view/icon-view-style.h
@@ -46,6 +46,8 @@ public:
     static IconViewStyle *getStyle();
     void release();
 
+    void drawPrimitive(PrimitiveElement element, const QStyleOption *option, QPainter *painter, const QWidget *widget = nullptr) const override;
+
     void drawControl(QStyle::ControlElement element,
                      const QStyleOption *option,
                      QPainter *painter,

--- a/libpeony-qt/controls/directory-view/view/icon-view/icon-view.cpp
+++ b/libpeony-qt/controls/directory-view/view/icon-view/icon-view.cpp
@@ -53,6 +53,9 @@ using namespace Peony::DirectoryView;
 
 IconView::IconView(QWidget *parent) : QListView(parent)
 {
+    setAttribute(Qt::WA_TranslucentBackground);
+    viewport()->setAttribute(Qt::WA_TranslucentBackground);
+
     setStyle(IconViewStyle::getStyle());
     //FIXME: do not create proxy in view itself.
     IconViewDelegate *delegate = new IconViewDelegate(this);
@@ -247,7 +250,7 @@ void IconView::resetEditTriggerTimer()
 void IconView::paintEvent(QPaintEvent *e)
 {
     QPainter p(this->viewport());
-    p.fillRect(this->geometry(), this->palette().base());
+    //p.fillRect(this->geometry(), this->palette().base());
     if (m_repaint_timer.isActive()) {
         m_repaint_timer.stop();
         QTimer::singleShot(100, [this](){

--- a/libpeony-qt/controls/directory-view/view/icon-view/icon-view.cpp
+++ b/libpeony-qt/controls/directory-view/view/icon-view/icon-view.cpp
@@ -250,7 +250,14 @@ void IconView::resetEditTriggerTimer()
 void IconView::paintEvent(QPaintEvent *e)
 {
     QPainter p(this->viewport());
+    p.setRenderHint(QPainter::Antialiasing);
     //p.fillRect(this->geometry(), this->palette().base());
+    QPainterPath path;
+    path.setFillRule(Qt::WindingFill);
+    path.addRoundedRect(this->rect().adjusted(0, 0, -1, -1), 6, 6);
+    path.addRect(0, 0, this->width(), 6);
+    path.addRect(0, 0, 6, this->height());
+    p.fillPath(path, this->palette().base());
     if (m_repaint_timer.isActive()) {
         m_repaint_timer.stop();
         QTimer::singleShot(100, [this](){

--- a/libpeony-qt/controls/directory-view/view/icon-view/icon-view.cpp
+++ b/libpeony-qt/controls/directory-view/view/icon-view/icon-view.cpp
@@ -219,16 +219,17 @@ void IconView::mousePressEvent(QMouseEvent *e)
         return;
     }
 
-    qDebug()<<"IconView::mousePressEvent, m_edit_trigger_timer"<<m_edit_trigger_timer.isActive()<<m_clickTimer->isActive();
-    //only trigger edit state at single click
-    m_clickTimer->start(500);
-    if (indexAt(e->pos()) == m_last_index && m_last_index.isValid()) {
-        m_editValid = true;
-        if(m_edit_trigger_timer.isActive()){
-            slotSingleClicked();
-            return;
-        }
-    }
+    //qDebug()<<"IconView::mousePressEvent, m_edit_trigger_timer"<<m_edit_trigger_timer.isActive()<<m_clickTimer->isActive();
+    //only trigger edit state at single click;
+    //click timer can not put in the press event, it has conflict with dragEvent
+//    m_clickTimer->start(500);
+//    if (indexAt(e->pos()) == m_last_index && m_last_index.isValid()) {
+//        m_editValid = true;
+//        if(m_edit_trigger_timer.isActive()){
+//            slotSingleClicked();
+//            return;
+//        }
+//    }
 }
 
 void IconView::mouseReleaseEvent(QMouseEvent *e)
@@ -241,6 +242,15 @@ void IconView::mouseReleaseEvent(QMouseEvent *e)
 
     if (!m_edit_trigger_timer.isActive() && indexAt(e->pos()).isValid() && this->selectedIndexes().count() == 1) {
         resetEditTriggerTimer();
+    }
+
+    m_clickTimer->start(500);
+    if (indexAt(e->pos()) == m_last_index && m_last_index.isValid()) {
+        m_editValid = true;
+        if(m_edit_trigger_timer.isActive()){
+            slotSingleClicked();
+            return;
+        }
     }
 }
 

--- a/libpeony-qt/controls/directory-view/view/icon-view/icon-view.cpp
+++ b/libpeony-qt/controls/directory-view/view/icon-view/icon-view.cpp
@@ -72,6 +72,10 @@ IconView::IconView(QWidget *parent) : QListView(parent)
 
     setGridSize(QSize(115, 135));
     setIconSize(QSize(64, 64));
+
+    m_clickTimer = new QTimer(this);
+    m_editValid = false;
+    connect(m_clickTimer, &QTimer::timeout, this, &IconView::slotSingleClicked);
 }
 
 IconView::~IconView()
@@ -208,17 +212,21 @@ void IconView::dropEvent(QDropEvent *e)
 
 void IconView::mousePressEvent(QMouseEvent *e)
 {
+    m_editValid = false;
     QListView::mousePressEvent(e);
 
     if (e->button() != Qt::LeftButton) {
         return;
     }
 
-    qDebug()<<m_edit_trigger_timer.isActive()<<m_edit_trigger_timer.interval();
+    qDebug()<<"IconView::mousePressEvent, m_edit_trigger_timer"<<m_edit_trigger_timer.isActive()<<m_clickTimer->isActive();
+    //only trigger edit state at single click
+    m_clickTimer->start(500);
     if (indexAt(e->pos()) == m_last_index && m_last_index.isValid()) {
-        if (m_edit_trigger_timer.isActive()) {
-            setIndexWidget(m_last_index, nullptr);
-            //edit(m_last_index);
+        m_editValid = true;
+        if(m_edit_trigger_timer.isActive()){
+            slotSingleClicked();
+            return;
         }
     }
 }
@@ -236,14 +244,23 @@ void IconView::mouseReleaseEvent(QMouseEvent *e)
     }
 }
 
+void IconView::mouseDoubleClickEvent(QMouseEvent *event)
+{
+    m_clickTimer->stop();
+    m_edit_trigger_timer.stop();
+
+    QListView::mouseDoubleClickEvent(event);
+}
+
 void IconView::resetEditTriggerTimer()
 {
     m_edit_trigger_timer.disconnect();
     m_edit_trigger_timer.stop();
     QTimer::singleShot(750, [&](){
-        qDebug()<<"start";
+        qDebug()<<"IconView::resetEditTriggerTimer()"<<"start";
         m_edit_trigger_timer.setSingleShot(true);
         m_edit_trigger_timer.start(1000);
+        m_editValid = false;
     });
 }
 
@@ -282,6 +299,19 @@ void IconView::wheelEvent(QWheelEvent *e)
         this->viewport()->update();
 }
 
+void IconView::slotSingleClicked()
+{
+    qDebug()<<"IconView::slotSingleClicked()"<<m_edit_trigger_timer.isActive()<<m_editValid;
+    m_clickTimer->stop();
+    if (m_edit_trigger_timer.isActive() && m_editValid) {
+        qDebug()<<"start edit"<<"***************************";
+        setIndexWidget(m_last_index, nullptr);
+        edit(m_last_index);
+        m_edit_trigger_timer.stop();
+    }
+    m_editValid = false;
+}
+
 void IconView::bindModel(FileItemModel *sourceModel, FileItemProxyFilterSortModel *proxyModel)
 {
     m_model = sourceModel;
@@ -301,9 +331,14 @@ void IconView::bindModel(FileItemModel *sourceModel, FileItemProxyFilterSortMode
         //Q_EMIT m_proxy->viewSelectionChanged();
         if (currentSelections.count() == 1) {
             m_last_index = currentSelections.first();
-            this->resetEditTriggerTimer();
+            //qDebug()<<"IconView::bindModel:"<<"selection changed: "<<"resetEditTriggerTimer";
+            //this->resetEditTriggerTimer();
         } else {
             m_last_index = QModelIndex();
+        }
+
+        if (currentSelections.count() == 1) {
+            this->resetEditTriggerTimer();
         }
     });
 }

--- a/libpeony-qt/controls/directory-view/view/icon-view/icon-view.h
+++ b/libpeony-qt/controls/directory-view/view/icon-view/icon-view.h
@@ -125,14 +125,21 @@ protected:
     void mousePressEvent(QMouseEvent *e) override;
     void mouseReleaseEvent(QMouseEvent *e) override;
 
+    void mouseDoubleClickEvent(QMouseEvent *event) override;
+
     void paintEvent(QPaintEvent *e) override;
     void resizeEvent(QResizeEvent *e) override;
 
     void wheelEvent(QWheelEvent *e) override;
 
+private Q_SLOTS:
+    void slotSingleClicked();
+
 private:
     QTimer m_edit_trigger_timer;
     QTimer m_repaint_timer;
+    QTimer* m_clickTimer;
+    bool  m_editValid;
     QModelIndex m_last_index;
 
     DirectoryViewProxyIface *m_proxy = nullptr;

--- a/libpeony-qt/controls/directory-view/view/icon-view/icon-view.h
+++ b/libpeony-qt/controls/directory-view/view/icon-view/icon-view.h
@@ -116,7 +116,6 @@ protected:
      * \deprecated
      */
     void changeZoomLevel();
-    void resetEditTriggerTimer();
 
     void dragEnterEvent(QDragEnterEvent *e) override;
     void dragMoveEvent(QDragMoveEvent *e) override;
@@ -133,13 +132,14 @@ protected:
     void wheelEvent(QWheelEvent *e) override;
 
 private Q_SLOTS:
-    void slotSingleClicked();
+    void slotRename();
 
 private:
-    QTimer m_edit_trigger_timer;
     QTimer m_repaint_timer;
-    QTimer* m_clickTimer;
+
     bool  m_editValid;
+    QTimer* m_renameTimer;
+
     QModelIndex m_last_index;
 
     DirectoryViewProxyIface *m_proxy = nullptr;

--- a/libpeony-qt/controls/directory-view/view/list-view/list-view.cpp
+++ b/libpeony-qt/controls/directory-view/view/list-view/list-view.cpp
@@ -128,18 +128,6 @@ void ListView::mousePressEvent(QMouseEvent *e)
         return;
     }
 
-    if (e->button() == Qt::LeftButton) {
-        //only trigger edit state at single click
-        qDebug()<<"ListView::mousePressEvent(QMouseEvent *e)"<<m_edit_trigger_timer.isActive();
-        m_clickTimer->start(500);
-        if (indexAt(e->pos()).row() == m_last_index.row() && m_last_index.isValid()) {
-            m_editValid = true;
-            if(m_edit_trigger_timer.isActive()){
-                slotSingleClicked();
-                return;
-            }
-        }
-    }
 }
 
 void ListView::mouseReleaseEvent(QMouseEvent *e)
@@ -163,6 +151,19 @@ void ListView::mouseReleaseEvent(QMouseEvent *e)
     }
     if (!m_edit_trigger_timer.isActive() && indexAt(e->pos()).isValid() && all_index_in_same_row) {
         resetEditTriggerTimer();
+    }
+
+    if (e->button() == Qt::LeftButton) {
+        //only trigger edit state at single click
+        qDebug()<<"ListView::mousePressEvent(QMouseEvent *e)"<<m_edit_trigger_timer.isActive();
+        m_clickTimer->start(500);
+        if (indexAt(e->pos()).row() == m_last_index.row() && m_last_index.isValid()) {
+            m_editValid = true;
+            if(m_edit_trigger_timer.isActive()){
+                slotSingleClicked();
+                return;
+            }
+        }
     }
 }
 

--- a/libpeony-qt/controls/directory-view/view/list-view/list-view.h
+++ b/libpeony-qt/controls/directory-view/view/list-view/list-view.h
@@ -99,13 +99,20 @@ public Q_SLOTS:
 protected:
     void mousePressEvent(QMouseEvent *e) override;
     void mouseReleaseEvent(QMouseEvent *e) override;
+    void mouseDoubleClickEvent(QMouseEvent *event) override;
+
     void resetEditTriggerTimer();
 
+private Q_SLOTS:
+    void slotSingleClicked();
 private:
     FileItemModel *m_model = nullptr;
     FileItemProxyFilterSortModel *m_proxy_model = nullptr;
 
     QTimer m_edit_trigger_timer;
+    QTimer* m_clickTimer;
+    bool  m_editValid;
+
     QModelIndex m_last_index;
 
     DirectoryViewProxyIface *m_proxy = nullptr;

--- a/libpeony-qt/controls/directory-view/view/list-view/list-view.h
+++ b/libpeony-qt/controls/directory-view/view/list-view/list-view.h
@@ -101,16 +101,15 @@ protected:
     void mouseReleaseEvent(QMouseEvent *e) override;
     void mouseDoubleClickEvent(QMouseEvent *event) override;
 
-    void resetEditTriggerTimer();
+    void dragEnterEvent(QDragEnterEvent *e) override;
 
 private Q_SLOTS:
-    void slotSingleClicked();
+    void slotRename();
 private:
     FileItemModel *m_model = nullptr;
     FileItemProxyFilterSortModel *m_proxy_model = nullptr;
 
-    QTimer m_edit_trigger_timer;
-    QTimer* m_clickTimer;
+    QTimer* m_renameTimer;
     bool  m_editValid;
 
     QModelIndex m_last_index;

--- a/libpeony-qt/controls/menu/directory-view-menu/directory-view-menu.cpp
+++ b/libpeony-qt/controls/menu/directory-view-menu/directory-view-menu.cpp
@@ -74,7 +74,7 @@ DirectoryViewMenu::DirectoryViewMenu(DirectoryViewWidget *directoryView, QWidget
     fillActions();
 }
 
-DirectoryViewMenu::DirectoryViewMenu(FMWindow *window, QWidget *parent) : QMenu(parent)
+DirectoryViewMenu::DirectoryViewMenu(FMWindowIface *window, QWidget *parent) : QMenu(parent)
 {
     m_top_window = window;
     m_view = window->getCurrentPage()->getView();

--- a/libpeony-qt/controls/menu/directory-view-menu/directory-view-menu.cpp
+++ b/libpeony-qt/controls/menu/directory-view-menu/directory-view-menu.cpp
@@ -151,7 +151,9 @@ const QList<QAction *> DirectoryViewMenu::constructOpenOpActions()
     if (isBackgroundMenu) {
         l<<addAction(QIcon::fromTheme("window-new-symbolic"), tr("Open in &New Window"));
         connect(l.last(), &QAction::triggered, [=](){
-            FMWindow *newWindow = new FMWindow(m_directory);
+            auto factory = m_top_window->getFactory();
+            auto windowIface = factory->create(m_directory);
+            auto newWindow = dynamic_cast<QWidget *>(windowIface);
             newWindow->setAttribute(Qt::WA_DeleteOnClose);
             //FIXME: show when prepared?
             newWindow->show();
@@ -179,7 +181,9 @@ const QList<QAction *> DirectoryViewMenu::constructOpenOpActions()
                 });
                 l<<addAction(QIcon::fromTheme("window-new-symbolic"), tr("Open \"%1\" in &New Window").arg(displayName));
                 connect(l.last(), &QAction::triggered, [=](){
-                    FMWindow *newWindow = new FMWindow(m_selections.first());
+                    auto factory = m_top_window->getFactory();
+                    auto windowIface = factory->create(m_selections.first());
+                    auto newWindow = dynamic_cast<QWidget *>(windowIface);
                     newWindow->setAttribute(Qt::WA_DeleteOnClose);
                     //FIXME: show when prepared?
                     newWindow->show();
@@ -566,17 +570,19 @@ const QList<QAction *> DirectoryViewMenu::constructSearchActions()
             for (auto uri : m_selections) {
                 auto parentUri = FileUtils::getParentUri(uri);
                 if (!parentUri.isNull()) {
-                    FMWindow *newWindow = new FMWindow(parentUri);
+                    auto factory = this->m_top_window->getFactory();
+                    auto *windowIface = factory->create(parentUri);
+                    auto newWindow = dynamic_cast<QWidget *>(windowIface);
                     auto selection = m_selections;
 #if QT_VERSION > QT_VERSION_CHECK(5, 12, 0)
                     QTimer::singleShot(1000, newWindow, [=](){
                         if (newWindow)
-                            newWindow->setCurrentSelectionUris(selection);
+                            windowIface->setCurrentSelectionUris(selection);
                     });
 #else
                     QTimer::singleShot(1000, [=](){
                         if (newWindow)
-                            newWindow->setCurrentSelectionUris(selection);
+                            windowIface->setCurrentSelectionUris(selection);
                     });
 #endif
                     newWindow->show();

--- a/libpeony-qt/controls/menu/directory-view-menu/directory-view-menu.h
+++ b/libpeony-qt/controls/menu/directory-view-menu/directory-view-menu.h
@@ -30,7 +30,7 @@
 
 namespace Peony {
 
-class FMWindow;
+class FMWindowIface;
 
 /*!
  * \brief The DirectoryViewMenu class
@@ -49,7 +49,7 @@ public:
      * \deprecated
      */
     explicit DirectoryViewMenu(DirectoryViewWidget *directoryView, QWidget *parent = nullptr);
-    explicit DirectoryViewMenu(FMWindow *window, QWidget *parent = nullptr);
+    explicit DirectoryViewMenu(FMWindowIface *window, QWidget *parent = nullptr);
 
     const QStringList &urisToEdit() {return m_uris_to_edit;}
 
@@ -66,7 +66,7 @@ protected:
     const QList<QAction *> constructSearchActions();
 
 private:
-    FMWindow *m_top_window;
+    FMWindowIface *m_top_window;
 
     DirectoryViewWidget *m_view;
     QString m_directory;

--- a/libpeony-qt/controls/menu/menu-plugin-manager.h
+++ b/libpeony-qt/controls/menu/menu-plugin-manager.h
@@ -68,6 +68,26 @@ private:
     bool m_enable = true;
 };
 
+class FileLabelInternalMenuPlugin : public QObject, public MenuPluginInterface
+{
+    Q_OBJECT
+public:
+    explicit FileLabelInternalMenuPlugin(QObject *parent);
+
+    PluginInterface::PluginType pluginType() override {return PluginInterface::MenuPlugin;}
+    const QString name() override {return tr("Peony File Labels Menu Extension");}
+    const QString description() override {return tr("Tag a File with Menu.");}
+    const QIcon icon() override {return QIcon::fromTheme("emblem-symbolic-link");}
+    void setEnable(bool enable) override {m_enable = enable;}
+    bool isEnable() override {return m_enable;}
+
+    QString testPlugin() override {return "test create file label";}
+    QList<QAction *> menuActions(Types types, const QString &uri, const QStringList &selectionUris) override;
+
+private:
+    bool m_enable = true;
+};
+
 }
 
 #endif // MENUPLUGINMANAGER_H

--- a/libpeony-qt/controls/navigation-bar/advanced-location-bar.cpp
+++ b/libpeony-qt/controls/navigation-bar/advanced-location-bar.cpp
@@ -111,10 +111,9 @@ void AdvancedLocationBar::finishEdit()
     Q_EMIT m_edit->returnPressed();
 }
 
-void AdvancedLocationBar::switchEditMode()
+void AdvancedLocationBar::switchEditMode(bool bSearchMode)
 {
-    m_search_mode = ! m_search_mode;
-    if (m_search_mode)
+    if (bSearchMode)
     {
         m_layout->setCurrentWidget(m_search_bar);
         m_search_bar->setPlaceholderText(tr("Search Content..."));

--- a/libpeony-qt/controls/navigation-bar/advanced-location-bar.h
+++ b/libpeony-qt/controls/navigation-bar/advanced-location-bar.h
@@ -24,6 +24,7 @@
 #define ADVANCEDLOCATIONBAR_H
 
 #include <QWidget>
+#include <QLineEdit>
 #include "peony-core_global.h"
 
 class QStackedLayout;
@@ -43,19 +44,24 @@ public:
 Q_SIGNALS:
     void updateWindowLocationRequest(const QString &uri, bool addHistory = true, bool forceUpdate = false);
     void refreshRequest();
+    void searchRequest(const QString &key);
 
 public Q_SLOTS:
     void updateLocation(const QString &uri);
     void startEdit();
     void finishEdit();
+    void switchEditMode();
 
 private:
     QStackedLayout *m_layout;
 
     LocationBar *m_bar;
     PathEdit *m_edit;
+    QLineEdit *m_search_bar;
 
     QString m_text;
+
+    bool m_search_mode = false;
 };
 
 }

--- a/libpeony-qt/controls/navigation-bar/advanced-location-bar.h
+++ b/libpeony-qt/controls/navigation-bar/advanced-location-bar.h
@@ -50,7 +50,7 @@ public Q_SLOTS:
     void updateLocation(const QString &uri);
     void startEdit();
     void finishEdit();
-    void switchEditMode();
+    void switchEditMode(bool bSearchMode);
 
 private:
     QStackedLayout *m_layout;
@@ -60,8 +60,6 @@ private:
     QLineEdit *m_search_bar;
 
     QString m_text;
-
-    bool m_search_mode = false;
 };
 
 }

--- a/libpeony-qt/controls/navigation-bar/location-bar/location-bar.cpp
+++ b/libpeony-qt/controls/navigation-bar/location-bar/location-bar.cpp
@@ -150,7 +150,8 @@ void LocationBar::addButton(const QString &uri, bool setIcon, bool setMenu)
 
 void LocationBar::mousePressEvent(QMouseEvent *e)
 {
-    QToolBar::mousePressEvent(e);
+    //eat this event.
+    //QToolBar::mousePressEvent(e);
     qDebug()<<"black clicked";
     if (e->button() == Qt::LeftButton) {
         Q_EMIT blankClicked();

--- a/libpeony-qt/controls/navigation-bar/location-bar/location-bar.cpp
+++ b/libpeony-qt/controls/navigation-bar/location-bar/location-bar.cpp
@@ -36,6 +36,7 @@
 #include <QLineEdit>
 
 #include <QStandardPaths>
+#include <QStorageInfo>
 
 using namespace Peony;
 
@@ -77,6 +78,10 @@ void LocationBar::setRootUri(const QString &uri)
     while (!tmp.isEmpty()) {
         uris.prepend(tmp);
         QUrl url = tmp;
+        QStorageInfo mount = QStorageInfo(url.path());
+        if (mount.isValid())
+            break;
+
         if (url.path() == QStandardPaths::writableLocation(QStandardPaths::HomeLocation)) {
             break;
         }

--- a/libpeony-qt/controls/tool-bar/advance-search-bar.cpp
+++ b/libpeony-qt/controls/tool-bar/advance-search-bar.cpp
@@ -39,7 +39,7 @@
 
 using namespace Peony;
 
-AdvanceSearchBar::AdvanceSearchBar(FMWindow *window, QWidget *parent) : QScrollArea(parent)
+AdvanceSearchBar::AdvanceSearchBar(FMWindowIface *window, QWidget *parent) : QScrollArea(parent)
 {
     m_top_window = window;
     init();

--- a/libpeony-qt/controls/tool-bar/advance-search-bar.h
+++ b/libpeony-qt/controls/tool-bar/advance-search-bar.h
@@ -32,13 +32,13 @@
 
 namespace Peony {
 
-class FMWindow;
+class FMWindowIface;
 
 class AdvanceSearchBar : public QScrollArea
 {
     Q_OBJECT
 public:
-    explicit AdvanceSearchBar(FMWindow *window, QWidget *parent = nullptr);
+    explicit AdvanceSearchBar(FMWindowIface *window, QWidget *parent = nullptr);
 
 Q_SIGNALS:
 
@@ -62,7 +62,7 @@ protected:
     void init();
 
 private:
-    FMWindow *m_top_window;
+    FMWindowIface *m_top_window;
 
     QWidget *m_filter;
     QLineEdit *m_advanced_key, *m_search_path;

--- a/libpeony-qt/controls/tool-bar/tool-bar.cpp
+++ b/libpeony-qt/controls/tool-bar/tool-bar.cpp
@@ -332,7 +332,8 @@ void ToolBar::updateLocation(const QString &uri)
     if (uri.isNull())
         return;
 
-    bool isFileOpDisable = uri.startsWith("trash://") || uri.startsWith("search://");
+    bool isFileOpDisable = uri.startsWith("trash://") || uri.startsWith("search://")
+            || uri.startsWith("computer:///");
     for (auto action : m_file_op_actions) {
         action->setEnabled(!isFileOpDisable);
         if (uri.startsWith("search://")) {

--- a/libpeony-qt/effects/border-shadow-effect.cpp
+++ b/libpeony-qt/effects/border-shadow-effect.cpp
@@ -66,9 +66,6 @@ void BorderShadowEffect::setShadowColor(const QColor &color)
 void BorderShadowEffect::setWindowBackground(const QColor &color)
 {
     m_window_bg = color;
-    if (auto w = qobject_cast<QWidget *>(parent())) {
-        w->update();
-    }
 }
 
 void BorderShadowEffect::drawWindowShadowManually(QPainter *painter, const QRect &windowRect)

--- a/libpeony-qt/effects/border-shadow-effect.cpp
+++ b/libpeony-qt/effects/border-shadow-effect.cpp
@@ -73,13 +73,13 @@ void BorderShadowEffect::draw(QPainter *painter)
     //draw window bg;
     auto sourceRect = boundingRect();
     auto contentRect = boundingRect().adjusted(m_padding, m_padding, -m_padding, -m_padding);
-    qDebug()<<contentRect;
+    //qDebug()<<contentRect;
     QPainterPath sourcePath;
     QPainterPath contentPath;
     sourcePath.addRect(sourceRect);
     contentPath.addRoundedRect(contentRect, m_x_border_radius, m_y_border_radius);
     auto targetPath = sourcePath - contentPath;
-    qDebug()<<contentPath;
+    //qDebug()<<contentPath;
     painter->fillPath(contentPath, m_window_bg);
 
     QPoint offset;
@@ -93,7 +93,7 @@ void BorderShadowEffect::draw(QPainter *painter)
         painter->setWorldTransform(QTransform());
         painter->drawPixmap(offset, pixmap);
     }
-    qDebug()<<this->boundingRect()<<offset;
+    //qDebug()<<this->boundingRect()<<offset;
     if (m_padding > 0) {
         //draw shadow
         QPixmap pixmap(sourceRect.size().width(), sourceRect.height());

--- a/libpeony-qt/effects/border-shadow-effect.cpp
+++ b/libpeony-qt/effects/border-shadow-effect.cpp
@@ -68,6 +68,38 @@ void BorderShadowEffect::setWindowBackground(const QColor &color)
     }
 }
 
+void BorderShadowEffect::drawWindowShadowManually(QPainter *painter, const QRect &windowRect)
+{
+    //draw window bg;
+    QRect sourceRect = windowRect;
+    auto contentRect = sourceRect.adjusted(m_padding, m_padding, -m_padding, -m_padding);
+    //qDebug()<<contentRect;
+    QPainterPath sourcePath;
+    QPainterPath contentPath;
+    sourcePath.addRect(sourceRect);
+    contentPath.addRoundedRect(contentRect, m_x_border_radius, m_y_border_radius);
+    auto targetPath = sourcePath - contentPath;
+    //qDebug()<<contentPath;
+    painter->fillPath(contentPath, m_window_bg);
+
+    //qDebug()<<this->boundingRect()<<offset;
+    if (m_padding > 0) {
+        //draw shadow
+        QPixmap pixmap(sourceRect.size().width(), sourceRect.height());
+        pixmap.fill(Qt::transparent);
+        QPainter p(&pixmap);
+        p.fillPath(contentPath, m_shadow_color);
+        p.end();
+        QImage img = pixmap.toImage();
+        qt_blurImage(img, m_blur_radius, false, false);
+        pixmap.convertFromImage(img);
+        painter->save();
+        painter->setClipPath(sourcePath - contentPath);
+        painter->drawImage(QPoint(), img);
+        painter->restore();
+    }
+}
+
 void BorderShadowEffect::draw(QPainter *painter)
 {
     //draw window bg;

--- a/libpeony-qt/effects/border-shadow-effect.cpp
+++ b/libpeony-qt/effects/border-shadow-effect.cpp
@@ -22,6 +22,7 @@
 
 #include "border-shadow-effect.h"
 #include <QPainter>
+#include <QWidget>
 #include <QDebug>
 
 //qt's global function
@@ -62,6 +63,9 @@ void BorderShadowEffect::setShadowColor(const QColor &color)
 void BorderShadowEffect::setWindowBackground(const QColor &color)
 {
     m_window_bg = color;
+    if (auto w = qobject_cast<QWidget *>(parent())) {
+        w->update();
+    }
 }
 
 void BorderShadowEffect::draw(QPainter *painter)

--- a/libpeony-qt/effects/border-shadow-effect.cpp
+++ b/libpeony-qt/effects/border-shadow-effect.cpp
@@ -68,6 +68,11 @@ void BorderShadowEffect::setWindowBackground(const QColor &color)
     m_window_bg = color;
 }
 
+void BorderShadowEffect::setTransParentPath(const QPainterPath &path)
+{
+    m_transparent_path = path;
+}
+
 void BorderShadowEffect::drawWindowShadowManually(QPainter *painter, const QRect &windowRect)
 {
     //draw window bg;
@@ -80,7 +85,8 @@ void BorderShadowEffect::drawWindowShadowManually(QPainter *painter, const QRect
     contentPath.addRoundedRect(contentRect, m_x_border_radius, m_y_border_radius);
     auto targetPath = sourcePath - contentPath;
     //qDebug()<<contentPath;
-    painter->fillPath(contentPath, m_window_bg);
+    auto bgPath = contentPath - m_transparent_path;
+    painter->fillPath(bgPath, m_window_bg);
 
     //qDebug()<<this->boundingRect()<<offset;
     if (m_padding > 0) {

--- a/libpeony-qt/effects/border-shadow-effect.cpp
+++ b/libpeony-qt/effects/border-shadow-effect.cpp
@@ -1,0 +1,108 @@
+/*
+ * Peony-Qt's Library
+ *
+ * Copyright (C) 2020, Tianjin KYLIN Information Technology Co., Ltd.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this library.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Authors: Yue Lan <lanyue@kylinos.cn>
+ *
+ */
+
+#include "border-shadow-effect.h"
+#include <QPainter>
+#include <QDebug>
+
+//qt's global function
+export void qt_blurImage(QImage &blurImage, qreal radius, bool quality, int transposed);
+
+BorderShadowEffect::BorderShadowEffect(QObject *parent) : QGraphicsEffect(parent)
+{
+
+}
+
+void BorderShadowEffect::setBorderRadius(int radius)
+{
+    m_x_border_radius = radius;
+    m_y_border_radius = radius;
+}
+
+void BorderShadowEffect::setBorderRadius(int xradius, int yradius)
+{
+    m_x_border_radius = xradius;
+    m_y_border_radius = yradius;
+}
+
+void BorderShadowEffect::setBlurRadius(int radius)
+{
+    m_blur_radius = radius;
+}
+
+void BorderShadowEffect::setPadding(int padding)
+{
+    m_padding = padding;
+}
+
+void BorderShadowEffect::setShadowColor(const QColor &color)
+{
+    m_shadow_color = color;
+}
+
+void BorderShadowEffect::setWindowBackground(const QColor &color)
+{
+    m_window_bg = color;
+}
+
+void BorderShadowEffect::draw(QPainter *painter)
+{
+    //draw window bg;
+    auto sourceRect = boundingRect();
+    auto contentRect = boundingRect().adjusted(m_padding, m_padding, -m_padding, -m_padding);
+    qDebug()<<contentRect;
+    QPainterPath sourcePath;
+    QPainterPath contentPath;
+    sourcePath.addRect(sourceRect);
+    contentPath.addRoundedRect(contentRect, m_x_border_radius, m_y_border_radius);
+    auto targetPath = sourcePath - contentPath;
+    qDebug()<<contentPath;
+    painter->fillPath(contentPath, m_window_bg);
+
+    QPoint offset;
+    if (sourceIsPixmap()) {
+        // No point in drawing in device coordinates (pixmap will be scaled anyways).
+        const QPixmap pixmap = sourcePixmap(Qt::LogicalCoordinates, &offset, QGraphicsEffect::PadToTransparentBorder);
+        painter->drawPixmap(offset, pixmap);
+    } else {
+        // Draw pixmap in device coordinates to avoid pixmap scaling;
+        const QPixmap pixmap = sourcePixmap(Qt::DeviceCoordinates, &offset, QGraphicsEffect::PadToTransparentBorder);
+        painter->setWorldTransform(QTransform());
+        painter->drawPixmap(offset, pixmap);
+    }
+    qDebug()<<this->boundingRect()<<offset;
+    if (m_padding > 0) {
+        //draw shadow
+        QPixmap pixmap(sourceRect.size().width(), sourceRect.height());
+        pixmap.fill(Qt::transparent);
+        QPainter p(&pixmap);
+        p.fillPath(contentPath, m_shadow_color);
+        p.end();
+        QImage img = pixmap.toImage();
+        qt_blurImage(img, m_blur_radius, false, false);
+        pixmap.convertFromImage(img);
+        painter->save();
+        painter->setClipPath(sourcePath - contentPath);
+        painter->drawImage(QPoint(), img);
+        painter->restore();
+    }
+}

--- a/libpeony-qt/effects/border-shadow-effect.cpp
+++ b/libpeony-qt/effects/border-shadow-effect.cpp
@@ -73,7 +73,7 @@ void BorderShadowEffect::setTransParentPath(const QPainterPath &path)
     m_transparent_path = path;
 }
 
-void BorderShadowEffect::drawWindowShadowManually(QPainter *painter, const QRect &windowRect)
+void BorderShadowEffect::drawWindowShadowManually(QPainter *painter, const QRect &windowRect, bool fakeShadow)
 {
     //draw window bg;
     QRect sourceRect = windowRect;
@@ -87,6 +87,17 @@ void BorderShadowEffect::drawWindowShadowManually(QPainter *painter, const QRect
     //qDebug()<<contentPath;
     auto bgPath = contentPath - m_transparent_path;
     painter->fillPath(bgPath, m_window_bg);
+
+    if (fakeShadow) {
+        painter->save();
+        auto color = m_shadow_color;
+        color.setAlphaF(0.1);
+        painter->setPen(color);
+        painter->setBrush(Qt::transparent);
+        painter->drawPath(contentPath);
+        painter->restore();
+        return;
+    }
 
     //qDebug()<<this->boundingRect()<<offset;
     if (m_padding > 0) {

--- a/libpeony-qt/effects/border-shadow-effect.h
+++ b/libpeony-qt/effects/border-shadow-effect.h
@@ -57,6 +57,8 @@ public:
 
     void setWindowBackground(const QColor &color);
 
+    void drawWindowShadowManually(QPainter *painter, const QRect &windowRect);
+
 protected:
     void draw(QPainter *painter) override;
 

--- a/libpeony-qt/effects/border-shadow-effect.h
+++ b/libpeony-qt/effects/border-shadow-effect.h
@@ -1,0 +1,72 @@
+/*
+ * Peony-Qt's Library
+ *
+ * Copyright (C) 2020, Tianjin KYLIN Information Technology Co., Ltd.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this library.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Authors: Yue Lan <lanyue@kylinos.cn>
+ *
+ */
+
+#ifndef BORDERSHADOWEFFECT_H
+#define BORDERSHADOWEFFECT_H
+
+#include <QGraphicsEffect>
+
+/*!
+ * \brief The BorderShadowEffect class
+ * \details
+ * This class is used to decorate a frameless window.
+ * It provides a border shadow which can be adjusted.
+ *
+ * The effect is similar to QGraphicsDropShadowEffects,
+ * but it doesn't blur allow the window. It just render
+ * a border for toplevel window, whatever if the window
+ * is transparent and whatever element on the window.
+ *
+ * \note
+ * To let the effect works,
+ * You have to use it on toplevel window, and let the
+ * window has an invisible contents margins.
+ *
+ * If your window has a border radius, use setBorderRadius()
+ * for matching your window border rendering.
+ */
+class BorderShadowEffect : public QGraphicsEffect
+{
+    Q_OBJECT
+public:
+    explicit BorderShadowEffect(QObject *parent = nullptr);
+    void setBorderRadius(int radius);
+    void setBorderRadius(int xradius, int yradius);
+    void setBlurRadius(int radius);
+    void setPadding(int padding);
+    void setShadowColor(const QColor &color);
+
+    void setWindowBackground(const QColor &color);
+
+protected:
+    void draw(QPainter *painter) override;
+
+private:
+    int m_x_border_radius = 0;
+    int m_y_border_radius = 0;
+    int m_blur_radius = 0;
+    int m_padding = 0;
+    QColor m_shadow_color = QColor(63, 63, 63, 180); // dark gray
+    QColor m_window_bg = Qt::transparent;
+};
+
+#endif // BORDERSHADOWEFFECT_H

--- a/libpeony-qt/effects/border-shadow-effect.h
+++ b/libpeony-qt/effects/border-shadow-effect.h
@@ -69,6 +69,9 @@ private:
     int m_padding = 0;
     QColor m_shadow_color = QColor(63, 63, 63, 180); // dark gray
     QColor m_window_bg = Qt::transparent;
+
+    QImage m_cache_shadow;
+    bool m_force_update_cache = false;
 };
 
 #endif // BORDERSHADOWEFFECT_H

--- a/libpeony-qt/effects/border-shadow-effect.h
+++ b/libpeony-qt/effects/border-shadow-effect.h
@@ -57,6 +57,8 @@ public:
 
     void setWindowBackground(const QColor &color);
 
+    void setTransParentPath(const QPainterPath &path);
+
     void drawWindowShadowManually(QPainter *painter, const QRect &windowRect);
 
 protected:
@@ -72,6 +74,8 @@ private:
 
     QImage m_cache_shadow;
     bool m_force_update_cache = false;
+
+    QPainterPath m_transparent_path;
 };
 
 #endif // BORDERSHADOWEFFECT_H

--- a/libpeony-qt/effects/border-shadow-effect.h
+++ b/libpeony-qt/effects/border-shadow-effect.h
@@ -59,7 +59,7 @@ public:
 
     void setTransParentPath(const QPainterPath &path);
 
-    void drawWindowShadowManually(QPainter *painter, const QRect &windowRect);
+    void drawWindowShadowManually(QPainter *painter, const QRect &windowRect, bool fakeShadow = false);
 
 protected:
     void draw(QPainter *painter) override;

--- a/libpeony-qt/effects/effects.pri
+++ b/libpeony-qt/effects/effects.pri
@@ -1,0 +1,7 @@
+INCLUDEPATH += $$PWD
+
+HEADERS += \
+    $$PWD/border-shadow-effect.h
+
+SOURCES += \
+    $$PWD/border-shadow-effect.cpp

--- a/libpeony-qt/file-meta-info.cpp
+++ b/libpeony-qt/file-meta-info.cpp
@@ -153,19 +153,26 @@ void FileMetaInfo::removeMetaInfo(const QString &key)
         realKey = "metadata::" + key;
     m_meta_hash.remove(realKey);
     GFile *file = g_file_new_for_uri(m_uri.toUtf8().constData());
-    GFileInfo *info = g_file_info_new();
-    std::string tmp = realKey.toStdString();
-    g_file_info_set_attribute(info, tmp.c_str(), G_FILE_ATTRIBUTE_TYPE_STRING, nullptr);
-    g_file_info_remove_attribute(info, tmp.c_str());
-    //FIXME: should i add callback?
-    g_file_set_attributes_async(file,
-                                info,
-                                G_FILE_QUERY_INFO_NOFOLLOW_SYMLINKS,
-                                0,
-                                nullptr,
-                                nullptr,
-                                nullptr);
-    g_object_unref(info);
+    g_file_set_attribute(file,
+                         realKey.toUtf8().constData(),
+                         G_FILE_ATTRIBUTE_TYPE_INVALID,
+                         nullptr,
+                         G_FILE_QUERY_INFO_NONE,
+                         nullptr,
+                         nullptr);
+//    GFileInfo *info = g_file_info_new();
+//    std::string tmp = realKey.toStdString();
+//    //g_file_info_set_attribute(info, realKey.toUtf8(), G_FILE_ATTRIBUTE_TYPE_INVALID, nullptr);
+//    g_file_info_remove_attribute(info, realKey.toUtf8());
+//    //FIXME: should i add callback?
+//    g_file_set_attributes_async(file,
+//                                info,
+//                                G_FILE_QUERY_INFO_NOFOLLOW_SYMLINKS,
+//                                0,
+//                                nullptr,
+//                                nullptr,
+//                                nullptr);
+//    g_object_unref(info);
     g_object_unref(file);
     m_mutex.unlock();
 }

--- a/libpeony-qt/file-watcher.cpp
+++ b/libpeony-qt/file-watcher.cpp
@@ -23,7 +23,10 @@
 #include "file-watcher.h"
 #include "gerror-wrapper.h"
 
+#include "file-label-model.h"
+
 #include <QUrl>
+#include "file-utils.h"
 
 #include <QDebug>
 
@@ -35,6 +38,14 @@ FileWatcher::FileWatcher(QString uri, QObject *parent) : QObject(parent)
     m_target_uri = uri;
     m_file = g_file_new_for_uri(uri.toUtf8().constData());
     m_cancellable = g_cancellable_new();
+
+    connect(FileLabelModel::getGlobalModel(), &FileLabelModel::fileLabelChanged, this, [=](const QString &uri){
+        auto parentUri = FileUtils::getParentUri(uri);
+        if (parentUri == m_uri || parentUri == m_target_uri) {
+            Q_EMIT fileChanged(uri);
+            qDebug()<<"file label changed"<<uri;
+        }
+    });
 
     //monitor target file if existed.
     prepare();

--- a/libpeony-qt/libpeony-qt-header.pri
+++ b/libpeony-qt/libpeony-qt-header.pri
@@ -36,4 +36,6 @@ INCLUDEPATH += $$PWD/controls/tab-page
 
 INCLUDEPATH += $$PWD/controls/tool-bar
 
+INCLUDEPATH += $$PWD/effects
+
 INCLUDEPATH += $$PWD/../plugin-iface/

--- a/libpeony-qt/libpeony-qt-header.pri
+++ b/libpeony-qt/libpeony-qt-header.pri
@@ -7,6 +7,8 @@ INCLUDEPATH += $$PWD/convenient-utils
 INCLUDEPATH += $$PWD/controls
 INCLUDEPATH += $$PWD/windows
 
+INCLUDEPATH += $$PWD/effects
+
 INCLUDEPATH += $$PWD/controls/directory-view
 INCLUDEPATH += $$PWD/controls/directory-view/directory-view-factory
 INCLUDEPATH += $$PWD/controls/directory-view/delegate

--- a/libpeony-qt/libpeony-qt.pri
+++ b/libpeony-qt/libpeony-qt.pri
@@ -6,6 +6,7 @@ include(model/model.pri)
 include(vfs/vfs.pri)
 #plugin interface
 include(../plugin-iface/plugin-iface.pri)
+include(effects/effects.pri)
 
 include(convenient-utils/convenient-utils.pri)
 

--- a/libpeony-qt/model/file-item-proxy-filter-sort-model.cpp
+++ b/libpeony-qt/model/file-item-proxy-filter-sort-model.cpp
@@ -189,6 +189,60 @@ bool FileItemProxyFilterSortModel::filterAcceptsRow(int sourceRow, const QModelI
                      return false;
             }
         }
+
+        //check mutiple label filter conditions, file has any one of these label is accepted
+        if(m_show_label_names.size() >0 || m_show_label_colors.size() >0)
+        {
+            bool bfind = false;
+            QString uri = item->m_info->uri();
+            if (m_show_label_names.size() >0 )
+            {
+               auto names = FileLabelModel::getGlobalModel()->getFileLabels(uri);
+               for(auto temp : m_show_label_names)
+               {
+                   if(names.contains(temp))
+                   {
+                       bfind = true;
+                       break;
+                   }
+               }
+            }
+
+            if (! bfind && m_show_label_colors.size() >0)
+            {
+                auto colors = FileLabelModel::getGlobalModel()->getFileColors(uri);
+                for(auto temp : m_show_label_colors)
+                {
+                    if (colors.contains(temp))
+                    {
+                        bfind = true;
+                        break;
+                    }
+                }
+            }
+
+            if (! bfind)
+                return false;
+        }
+
+        //check the blur name, can use as search color labels
+        if (m_blur_name != "")
+        {
+            QString uri = item->m_info->uri();
+            auto names = FileLabelModel::getGlobalModel()->getFileLabels(uri);
+            bool find = false;
+            for(auto temp : names)
+            {
+                if ((m_case_sensitive && temp.indexOf(m_blur_name) >= 0) ||
+                   (! m_case_sensitive && temp.toLower().indexOf(m_blur_name.toLower()) >= 0))
+                {
+                    find = true;
+                    break;
+                }
+            }
+            if (! find)
+                return false;
+        }
     }
     return true;
 }
@@ -409,6 +463,29 @@ void FileItemProxyFilterSortModel::setFilterLabelConditions(QString name, QColor
 {
     m_label_name = name;
     m_label_color = color;
+    invalidateFilter();
+}
+
+void FileItemProxyFilterSortModel::setMutipleLabelConditions(QStringList names, QList<QColor> colors)
+{
+    m_show_label_names.clear();
+    m_show_label_colors.clear();
+
+    for(auto name : names)
+    {
+        m_show_label_names.append(name);
+    }
+    for(auto color : colors)
+    {
+        m_show_label_colors.append(color);
+    }
+    invalidateFilter();
+}
+
+void FileItemProxyFilterSortModel::setLabelBlurName(QString blurName, bool caseSensitive)
+{
+    m_blur_name = blurName;
+    m_case_sensitive = caseSensitive;
     invalidateFilter();
 }
 

--- a/libpeony-qt/model/file-item-proxy-filter-sort-model.h
+++ b/libpeony-qt/model/file-item-proxy-filter-sort-model.h
@@ -83,6 +83,10 @@ public:
     //set file label filter conditions, default value mean all files are accepted
     //use it without any paras can clear the filter conditions
     void setFilterLabelConditions(QString name = "", QColor color=Qt::transparent);
+    //select mutiple labels to filter files, file has any one of these label is accepted
+    void setMutipleLabelConditions(QStringList names, QList<QColor> colors);
+    //give blur name to search color labels, can set CaseSensitive or not
+    void setLabelBlurName(QString blurName = "", bool CaseSensitive = false);
 
     FileItem *itemFromIndex(const QModelIndex &proxyIndex);
     QModelIndex getSourceIndex(const QModelIndex &proxyIndex);
@@ -108,11 +112,15 @@ private:
     bool m_show_hidden = false;
     bool m_use_default_name_sort_order = true;
     bool m_folder_first = true;
+    bool m_case_sensitive = false;
+    QString m_blur_name = "";
     QString m_label_name = "";
     QColor m_label_color = Qt::transparent;
     const int ALL_FILE = 0;
     const quint64 K_BASE = 1000;
     int m_show_file_type=ALL_FILE, m_show_modify_time=ALL_FILE, m_show_file_size=ALL_FILE;
+    QStringList m_show_label_names;
+    QList<QColor> m_show_label_colors;
 };
 
 }

--- a/libpeony-qt/model/file-item-proxy-filter-sort-model.h
+++ b/libpeony-qt/model/file-item-proxy-filter-sort-model.h
@@ -26,6 +26,7 @@
 
 #include <QObject>
 #include <QSortFilterProxyModel>
+#include <QColor>
 
 #include "peony-core_global.h"
 
@@ -79,6 +80,9 @@ public:
     void setUseDefaultNameSortOrder(bool use);
     void setFolderFirst(bool folderFirst);
     void setFilterConditions(int fileType=0, int modifyTime=0, int fileSize=0);
+    //set file label filter conditions, default value mean all files are accepted
+    //use it without any paras can clear the filter conditions
+    void setFilterLabelConditions(QString name = "", QColor color=Qt::transparent);
 
     FileItem *itemFromIndex(const QModelIndex &proxyIndex);
     QModelIndex getSourceIndex(const QModelIndex &proxyIndex);
@@ -104,6 +108,8 @@ private:
     bool m_show_hidden = false;
     bool m_use_default_name_sort_order = true;
     bool m_folder_first = true;
+    QString m_label_name = "";
+    QColor m_label_color = Qt::transparent;
     const int ALL_FILE = 0;
     const quint64 K_BASE = 1000;
     int m_show_file_type=ALL_FILE, m_show_modify_time=ALL_FILE, m_show_file_size=ALL_FILE;

--- a/libpeony-qt/model/file-item.cpp
+++ b/libpeony-qt/model/file-item.cpp
@@ -243,9 +243,9 @@ void FileItem::findChildrenAsync()
             for (auto uri : uris) {
                 auto info = FileInfo::fromUri(uri);
                 auto item = new FileItem(info, this, m_model);
+                m_model->beginInsertRows(firstColumnIndex(), m_children->count(), m_children->count());
                 m_children->append(item);
-                m_model->insertRows(m_children->count() - 1, 1, firstColumnIndex());
-
+                m_model->endInsertRows();
                 auto infoJob = new FileInfoJob(info);
                 infoJob->setAutoDelete();
                 infoJob->connect(infoJob, &FileInfoJob::infoUpdated, this, [=](){

--- a/libpeony-qt/model/file-label-model.cpp
+++ b/libpeony-qt/model/file-label-model.cpp
@@ -197,7 +197,7 @@ const QList<int> FileLabelModel::getFileLabelIds(const QString &uri)
 {
     QList<int> l;
     auto metaInfo = Peony::FileMetaInfo::fromUri(uri);
-    if (metaInfo->getMetaInfoVariant(PEONY_FILE_LABEL_IDS).isNull())
+    if (! metaInfo || metaInfo->getMetaInfoVariant(PEONY_FILE_LABEL_IDS).isNull())
         return l;
     auto labels = metaInfo->getMetaInfoStringList(PEONY_FILE_LABEL_IDS);
     for (auto label : labels) {
@@ -210,7 +210,7 @@ const QStringList FileLabelModel::getFileLabels(const QString &uri)
 {
     QStringList l;
     auto metaInfo = Peony::FileMetaInfo::fromUri(uri);
-    if (metaInfo->getMetaInfoVariant(PEONY_FILE_LABEL_IDS).isNull())
+    if (! metaInfo || metaInfo->getMetaInfoVariant(PEONY_FILE_LABEL_IDS).isNull())
         return l;
     auto labels = metaInfo->getMetaInfoStringList(PEONY_FILE_LABEL_IDS);
     for (auto label : labels) {
@@ -227,7 +227,7 @@ const QList<QColor> FileLabelModel::getFileColors(const QString &uri)
 {
     QList<QColor> l;
     auto metaInfo = Peony::FileMetaInfo::fromUri(uri);
-    if (metaInfo->getMetaInfoVariant(PEONY_FILE_LABEL_IDS).isNull())
+    if (! metaInfo || metaInfo->getMetaInfoVariant(PEONY_FILE_LABEL_IDS).isNull())
         return l;
     auto labels = metaInfo->getMetaInfoStringList(PEONY_FILE_LABEL_IDS);
     for (auto label : labels) {
@@ -267,7 +267,7 @@ void FileLabelModel::addLabelToFile(const QString &uri, int labelId)
 {
     auto metaInfo = Peony::FileMetaInfo::fromUri(uri);
     QStringList labelIds;
-    if (!metaInfo->getMetaInfoVariant(PEONY_FILE_LABEL_IDS).isNull())
+    if (! metaInfo && !metaInfo->getMetaInfoVariant(PEONY_FILE_LABEL_IDS).isNull())
         labelIds = metaInfo->getMetaInfoStringList(PEONY_FILE_LABEL_IDS);
     labelIds<<QString::number(labelId);
     labelIds.removeDuplicates();
@@ -278,6 +278,8 @@ void FileLabelModel::addLabelToFile(const QString &uri, int labelId)
 void FileLabelModel::removeFileLabel(const QString &uri, int labelId)
 {
     auto metaInfo = Peony::FileMetaInfo::fromUri(uri);
+    if (! metaInfo)
+        return;
     if (labelId <= 0) {
         metaInfo->removeMetaInfo(PEONY_FILE_LABEL_IDS);
     } else {

--- a/libpeony-qt/model/file-label-model.cpp
+++ b/libpeony-qt/model/file-label-model.cpp
@@ -223,6 +223,23 @@ const QStringList FileLabelModel::getFileLabels(const QString &uri)
     return l;
 }
 
+const QList<QColor> FileLabelModel::getFileColors(const QString &uri)
+{
+    QList<QColor> l;
+    auto metaInfo = Peony::FileMetaInfo::fromUri(uri);
+    if (metaInfo->getMetaInfoVariant(PEONY_FILE_LABEL_IDS).isNull())
+        return l;
+    auto labels = metaInfo->getMetaInfoStringList(PEONY_FILE_LABEL_IDS);
+    for (auto label : labels) {
+        auto id = label.toInt();
+        auto item = itemFromId(id);
+        if (item) {
+            l<<item->color();
+        }
+    }
+    return l;
+}
+
 FileLabelItem *FileLabelModel::itemFromId(int id)
 {
     for (auto item : this->m_labels) {

--- a/libpeony-qt/model/file-label-model.cpp
+++ b/libpeony-qt/model/file-label-model.cpp
@@ -97,7 +97,7 @@ int FileLabelModel::lastLabelId()
 {
     m_label_settings = new QSettings(QSettings::UserScope, "org.ukui", "peony-qt", this);
     if (m_label_settings->value("lastid").isNull()) {
-        return -1;
+        return 0;
     } else {
         return m_label_settings->value("lastid").toInt();
     }
@@ -261,7 +261,7 @@ void FileLabelModel::addLabelToFile(const QString &uri, int labelId)
 void FileLabelModel::removeFileLabel(const QString &uri, int labelId)
 {
     auto metaInfo = Peony::FileMetaInfo::fromUri(uri);
-    if (labelId < 0) {
+    if (labelId <= 0) {
         metaInfo->removeMetaInfo(PEONY_FILE_LABEL_IDS);
     } else {
         if (metaInfo->getMetaInfoVariant(PEONY_FILE_LABEL_IDS).isNull())
@@ -307,6 +307,9 @@ bool FileLabelModel::setData(const QModelIndex &index, const QVariant &value, in
     if (data(index, role) != value) {
         // FIXME: Implement me!
         auto name = value.toString();
+        if (name.isEmpty()) {
+            return false;
+        }
         if (getLabels().contains(name)) {
             QMessageBox::critical(nullptr, tr("Error"), tr("Label or color is duplicated."));
             return false;

--- a/libpeony-qt/model/file-label-model.cpp
+++ b/libpeony-qt/model/file-label-model.cpp
@@ -1,0 +1,101 @@
+/*
+ * Peony-Qt's Library
+ *
+ * Copyright (C) 2020, Tianjin KYLIN Information Technology Co., Ltd.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this library.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Authors: Yue Lan <lanyue@kylinos.cn>
+ *
+ */
+
+#include "file-label-model.h"
+
+static FileLabelModel *global_instance = nullptr;
+
+FileLabelModel::FileLabelModel(QObject *parent)
+    : QAbstractListModel(parent)
+{
+    m_label_settings = new QSettings(QSettings::UserScope, "org.ukui", "peony-qt", this);
+    if (m_label_settings->value("id").isNull()) {
+        //init settings
+    }
+}
+
+FileLabelModel::~FileLabelModel()
+{
+
+}
+
+FileLabelModel *FileLabelModel::getGlobalModel()
+{
+    if (!global_instance) {
+        global_instance = new FileLabelModel;
+    }
+    return global_instance;
+}
+
+int FileLabelModel::rowCount(const QModelIndex &parent) const
+{
+    // For list models only the root node (an invalid parent) should return the list's size. For all
+    // other (valid) parents, rowCount() should return 0 so that it does not become a tree model.
+    if (parent.isValid())
+        return 0;
+
+    // FIXME: Implement me!
+    return 0;
+}
+
+QVariant FileLabelModel::data(const QModelIndex &index, int role) const
+{
+    if (!index.isValid())
+        return QVariant();
+
+    // FIXME: Implement me!
+    return QVariant();
+}
+
+bool FileLabelModel::setData(const QModelIndex &index, const QVariant &value, int role)
+{
+    if (data(index, role) != value) {
+        // FIXME: Implement me!
+        Q_EMIT dataChanged(index, index, QVector<int>() << role);
+        return true;
+    }
+    return false;
+}
+
+Qt::ItemFlags FileLabelModel::flags(const QModelIndex &index) const
+{
+    if (!index.isValid())
+        return Qt::NoItemFlags;
+
+    return Qt::ItemIsEditable; // FIXME: Implement me!
+}
+
+bool FileLabelModel::insertRows(int row, int count, const QModelIndex &parent)
+{
+    beginInsertRows(parent, row, row + count - 1);
+    // FIXME: Implement me!
+    endInsertRows();
+    return true;
+}
+
+bool FileLabelModel::removeRows(int row, int count, const QModelIndex &parent)
+{
+    beginRemoveRows(parent, row, row + count - 1);
+    // FIXME: Implement me!
+    endRemoveRows();
+    return true;
+}

--- a/libpeony-qt/model/file-label-model.h
+++ b/libpeony-qt/model/file-label-model.h
@@ -55,6 +55,9 @@ public:
     const QList<int> getFileLabelIds(const QString &uri);
     const QStringList getFileLabels(const QString &uri);
     FileLabelItem *itemFromId(int id);
+    FileLabelItem *itemFormIndex(const QModelIndex &index);
+
+    QList<FileLabelItem *> getAllFileLabelItems();
 
     // Basic functionality:
     int rowCount(const QModelIndex &parent = QModelIndex()) const override;
@@ -72,6 +75,13 @@ public:
 
     // Remove data:
     bool removeRows(int row, int count, const QModelIndex &parent = QModelIndex()) override;
+
+Q_SIGNALS:
+    void fileLabelChanged(const QString &uri);
+
+public Q_SLOTS:
+    void setName(FileLabelItem *item, const QString &name);
+    void setColor(FileLabelItem *item, const QColor &color);
 
 protected:
     void initLabelItems();

--- a/libpeony-qt/model/file-label-model.h
+++ b/libpeony-qt/model/file-label-model.h
@@ -28,6 +28,8 @@
 
 #include <QColor>
 
+#define PEONY_FILE_LABEL_IDS "peony-file-label-ids"
+
 class FileLabelItem;
 
 class FileLabelModel : public QAbstractListModel
@@ -46,6 +48,13 @@ public:
     void removeLabel(int id);
     void setLabelName(int id, const QString &name);
     void setLabelColor(int id, const QColor &color);
+
+    void addLabelToFile(const QString &uri, int labelId);
+    void removeFileLabel(const QString &uri, int labelId = -1);
+
+    const QList<int> getFileLabelIds(const QString &uri);
+    const QStringList getFileLabels(const QString &uri);
+    FileLabelItem *itemFromId(int id);
 
     // Basic functionality:
     int rowCount(const QModelIndex &parent = QModelIndex()) const override;

--- a/libpeony-qt/model/file-label-model.h
+++ b/libpeony-qt/model/file-label-model.h
@@ -26,6 +26,10 @@
 #include <QAbstractListModel>
 #include <QSettings>
 
+#include <QColor>
+
+class FileLabelItem;
+
 class FileLabelModel : public QAbstractListModel
 {
     Q_OBJECT
@@ -33,9 +37,15 @@ class FileLabelModel : public QAbstractListModel
 public:
     static FileLabelModel *getGlobalModel();
 
+    const QStringList getLabels();
+    const QList<QColor> getColors();
+
+    int lastLabelId();
+
     void addLabel(const QString &label, const QColor &color);
-    void removeLabel(const QString &label);
-    void setLabelColor(const QString &label, const QColor);
+    void removeLabel(int id);
+    void setLabelName(int id, const QString &name);
+    void setLabelColor(int id, const QColor &color);
 
     // Basic functionality:
     int rowCount(const QModelIndex &parent = QModelIndex()) const override;
@@ -54,11 +64,41 @@ public:
     // Remove data:
     bool removeRows(int row, int count, const QModelIndex &parent = QModelIndex()) override;
 
+protected:
+    void initLabelItems();
+    void addId();
+
 private:
     explicit FileLabelModel(QObject *parent = nullptr);
     ~FileLabelModel();
 
     QSettings *m_label_settings;
+
+    QList<FileLabelItem *> m_labels;
+};
+
+class FileLabelItem : public QObject
+{
+    friend class FileLabelModel;
+    Q_OBJECT
+public:
+    explicit FileLabelItem(QObject *parent = nullptr);
+
+    int id();
+    const QString name();
+    const QColor color();
+
+    void setName(const QString &name);
+    void setColor(const QColor &color);
+
+Q_SIGNALS:
+    void nameChanged(const QString &name);
+    void colorChanged(const QColor &color);
+
+private:
+    int m_id = -1; //invalid
+    QString m_name = nullptr;
+    QColor m_color = Qt::transparent;
 };
 
 #endif // FILELABELMODEL_H

--- a/libpeony-qt/model/file-label-model.h
+++ b/libpeony-qt/model/file-label-model.h
@@ -1,0 +1,64 @@
+/*
+ * Peony-Qt's Library
+ *
+ * Copyright (C) 2020, Tianjin KYLIN Information Technology Co., Ltd.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this library.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Authors: Yue Lan <lanyue@kylinos.cn>
+ *
+ */
+
+#ifndef FILELABELMODEL_H
+#define FILELABELMODEL_H
+
+#include <QAbstractListModel>
+#include <QSettings>
+
+class FileLabelModel : public QAbstractListModel
+{
+    Q_OBJECT
+
+public:
+    static FileLabelModel *getGlobalModel();
+
+    void addLabel(const QString &label, const QColor &color);
+    void removeLabel(const QString &label);
+    void setLabelColor(const QString &label, const QColor);
+
+    // Basic functionality:
+    int rowCount(const QModelIndex &parent = QModelIndex()) const override;
+
+    QVariant data(const QModelIndex &index, int role = Qt::DisplayRole) const override;
+
+    // Editable:
+    bool setData(const QModelIndex &index, const QVariant &value,
+                 int role = Qt::EditRole) override;
+
+    Qt::ItemFlags flags(const QModelIndex& index) const override;
+
+    // Add data:
+    bool insertRows(int row, int count, const QModelIndex &parent = QModelIndex()) override;
+
+    // Remove data:
+    bool removeRows(int row, int count, const QModelIndex &parent = QModelIndex()) override;
+
+private:
+    explicit FileLabelModel(QObject *parent = nullptr);
+    ~FileLabelModel();
+
+    QSettings *m_label_settings;
+};
+
+#endif // FILELABELMODEL_H

--- a/libpeony-qt/model/file-label-model.h
+++ b/libpeony-qt/model/file-label-model.h
@@ -54,6 +54,7 @@ public:
 
     const QList<int> getFileLabelIds(const QString &uri);
     const QStringList getFileLabels(const QString &uri);
+    const QList<QColor> getFileColors(const QString &uri);
     FileLabelItem *itemFromId(int id);
     FileLabelItem *itemFormIndex(const QModelIndex &index);
 

--- a/libpeony-qt/model/model.pri
+++ b/libpeony-qt/model/model.pri
@@ -6,6 +6,7 @@ HEADERS += \
     $$PWD/file-item.h \
     $$PWD/file-item-model.h \
     $$PWD/file-item-proxy-filter-sort-model.h \
+    $$PWD/file-label-model.h \
     $$PWD/side-bar-abstract-item.h \
     $$PWD/side-bar-model.h \
     $$PWD/side-bar-favorite-item.h \
@@ -20,6 +21,7 @@ SOURCES += \
     $$PWD/file-item.cpp \
     $$PWD/file-item-model.cpp \
     $$PWD/file-item-proxy-filter-sort-model.cpp \
+    $$PWD/file-label-model.cpp \
     $$PWD/side-bar-abstract-item.cpp \
     $$PWD/side-bar-model.cpp \
     $$PWD/side-bar-favorite-item.cpp \

--- a/libpeony-qt/model/side-bar-model.cpp
+++ b/libpeony-qt/model/side-bar-model.cpp
@@ -47,22 +47,22 @@ SideBarModel::SideBarModel(QObject *parent)
 
     m_root_children = new QVector<SideBarAbstractItem*>();
 
-    SideBarSeparatorItem *separator1 = new SideBarSeparatorItem(SideBarSeparatorItem::Large, nullptr, this, this);
-    m_root_children->append(separator1);
+//    SideBarSeparatorItem *separator1 = new SideBarSeparatorItem(SideBarSeparatorItem::Large, nullptr, this, this);
+//    m_root_children->append(separator1);
 
     SideBarFavoriteItem *favorite_root_item = new SideBarFavoriteItem(nullptr, nullptr, this);
     m_root_children->append(favorite_root_item);
     //favorite_root_item->findChildren();
 
-    SideBarSeparatorItem *separator2 = new SideBarSeparatorItem(SideBarSeparatorItem::Small, nullptr, this, this);
-    m_root_children->append(separator2);
+//    SideBarSeparatorItem *separator2 = new SideBarSeparatorItem(SideBarSeparatorItem::Small, nullptr, this, this);
+//    m_root_children->append(separator2);
 
     SideBarPersonalItem *personal_root_item = new SideBarPersonalItem(nullptr, nullptr, this);
     m_root_children->append(personal_root_item);
     //personal_root_item->findChildren();
 
-    SideBarSeparatorItem *separator3 = new SideBarSeparatorItem(SideBarSeparatorItem::Small, nullptr, this, this);
-    m_root_children->append(separator3);
+//    SideBarSeparatorItem *separator3 = new SideBarSeparatorItem(SideBarSeparatorItem::Small, nullptr, this, this);
+//    m_root_children->append(separator3);
 
     SideBarFileSystemItem *computerItem = new SideBarFileSystemItem(nullptr,
                                                                     nullptr,

--- a/libpeony-qt/windows/FMWindowIface.h
+++ b/libpeony-qt/windows/FMWindowIface.h
@@ -1,0 +1,83 @@
+/*
+ * Peony-Qt's Library
+ *
+ * Copyright (C) 2020, Tianjin KYLIN Information Technology Co., Ltd.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this library.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Authors: Yue Lan <lanyue@kylinos.cn>
+ *
+ */
+
+#ifndef FMWINDOWIFACE_H
+#define FMWINDOWIFACE_H
+
+#include "peony-core_global.h"
+#include <QStringList>
+#include "file-info.h"
+
+namespace Peony {
+
+class DirectoryViewContainer;
+
+class PEONYCORESHARED_EXPORT FMWindowIface
+{
+public:
+    virtual const QString getCurrentUri() = 0; //do not allow initialize this iface directly
+    virtual const QString getLastNonSearchUri() {return nullptr;}
+    virtual const QStringList getCurrentSelections() {return QStringList();}
+    virtual const QStringList getCurrentAllFileUris() {return QStringList();}
+    virtual const QList<std::shared_ptr<FileInfo>> getCurrentSelectionFileInfos() {return QList<std::shared_ptr<FileInfo>>();}
+    virtual DirectoryViewContainer *getCurrentPage() {return nullptr;}
+
+    virtual Qt::SortOrder getCurrentSortOrder() {return Qt::AscendingOrder;}
+    virtual int getCurrentSortColumn() {return 0;}
+
+    virtual bool getWindowShowHidden() {return false;}
+    virtual bool getWindowUseDefaultNameSortOrder() {return false;}
+    virtual bool getWindowSortFolderFirst() {return false;}
+
+    virtual const QString getCurrentPageViewType() {return nullptr;}
+
+    //slot
+    virtual void goToUri(const QString &uri, bool addHistory, bool forceUpdate = false) {}
+    virtual void addNewTabs(const QStringList &uris) {}
+
+    virtual void beginSwitchView(const QString &viewId) {}
+
+    virtual void refresh() {}
+    virtual void forceStopLoading() {}
+    virtual void advanceSearch() {}
+    virtual void clearRecord() {}
+    virtual void searchFilter(QString target_path, QString keyWord, bool search_file_name, bool search_content) {}
+    virtual void filterUpdate(int type_index=0, int time_index=0, int size_index=0) {}
+
+    virtual void setShowHidden(bool showHidden) {}
+    virtual void setShowHidden() {}
+    virtual void setUseDefaultNameSortOrder(bool use) {}
+    virtual void setSortFolderFirst(bool folderFirst) {}
+
+    virtual void onPreviewPageSwitch(const QString &uri) {}
+
+    virtual void setCurrentSelectionUris(const QStringList &uris) {}
+    virtual void setCurrentSortOrder (Qt::SortOrder order) {}
+    virtual void setCurrentSortColumn (int sortColumn) {}
+
+    virtual void editUri(const QString &uri) {}
+    virtual void editUris(const QStringList &uris) {}
+};
+}
+
+
+#endif // FMWINDOWIFACE_H

--- a/libpeony-qt/windows/FMWindowIface.h
+++ b/libpeony-qt/windows/FMWindowIface.h
@@ -30,10 +30,13 @@
 namespace Peony {
 
 class DirectoryViewContainer;
+class FMWindowFactory;
 
 class PEONYCORESHARED_EXPORT FMWindowIface
 {
 public:
+    virtual FMWindowFactory *getFactory() {return nullptr;}
+
     virtual const QString getCurrentUri() = 0; //do not allow initialize this iface directly
     virtual const QString getLastNonSearchUri() {return nullptr;}
     virtual const QStringList getCurrentSelections() {return QStringList();}

--- a/libpeony-qt/windows/fm-window-factory.cpp
+++ b/libpeony-qt/windows/fm-window-factory.cpp
@@ -1,0 +1,59 @@
+/*
+ * Peony-Qt's Library
+ *
+ * Copyright (C) 2020, Tianjin KYLIN Information Technology Co., Ltd.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this library.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Authors: Yue Lan <lanyue@kylinos.cn>
+ *
+ */
+
+#include "fm-window-factory.h"
+#include "fm-window.h"
+
+Peony::FMWindowFactory *global_instance = nullptr;
+
+Peony::FMWindowFactory::FMWindowFactory(QObject *parent) : QObject(parent)
+{
+
+}
+
+Peony::FMWindowFactory *Peony::FMWindowFactory::getInstance()
+{
+    if (!global_instance)
+        global_instance = new FMWindowFactory;
+    return global_instance;
+}
+
+Peony::FMWindowIface *Peony::FMWindowFactory::create(const QString &uri)
+{
+    return new FMWindow(uri);
+}
+
+Peony::FMWindowIface *Peony::FMWindowFactory::create(const QStringList &uris)
+{
+    if (uris.isEmpty())
+        return nullptr;
+    auto window = new FMWindow(uris.first());
+    QStringList l;
+    for (auto uri : uris) {
+        if (uris.indexOf(uri) != 0) {
+            l<<uri;
+        }
+    }
+    if (!l.isEmpty())
+        window->addNewTabs(l);
+    return window;
+}

--- a/libpeony-qt/windows/fm-window-factory.h
+++ b/libpeony-qt/windows/fm-window-factory.h
@@ -1,0 +1,44 @@
+/*
+ * Peony-Qt's Library
+ *
+ * Copyright (C) 2020, Tianjin KYLIN Information Technology Co., Ltd.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this library.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Authors: Yue Lan <lanyue@kylinos.cn>
+ *
+ */
+
+#ifndef FMWINDOWFACTORY_H
+#define FMWINDOWFACTORY_H
+
+#include <QObject>
+#include "FMWindowIface.h"
+
+namespace Peony {
+
+class FMWindowFactory : public QObject
+{
+    Q_OBJECT
+public:
+    static FMWindowFactory *getInstance();
+    explicit FMWindowFactory(QObject *parent = nullptr);
+
+    virtual FMWindowIface *create(const QString &uri = nullptr);
+    virtual FMWindowIface *create(const QStringList &uris);
+};
+
+}
+
+#endif // FMWINDOWFACTORY_H

--- a/libpeony-qt/windows/fm-window.cpp
+++ b/libpeony-qt/windows/fm-window.cpp
@@ -555,6 +555,11 @@ FMWindow::FMWindow(const QString &uri, QWidget *parent) : QMainWindow (parent)
     });
 }
 
+FMWindowFactory *FMWindow::getFactory()
+{
+    return FMWindowFactory::getInstance();
+}
+
 const QString FMWindow::getCurrentUri()
 {
     if (m_tab->getActivePage()) {

--- a/libpeony-qt/windows/fm-window.cpp
+++ b/libpeony-qt/windows/fm-window.cpp
@@ -461,8 +461,11 @@ FMWindow::FMWindow(const QString &uri, QWidget *parent) : QMainWindow (parent)
     auto propertiesWindowAction = new QAction(this);
     propertiesWindowAction->setShortcut(QKeySequence(Qt::ALT + Qt::Key_Return));
     connect(propertiesWindowAction, &QAction::triggered, this, [=](){
-        PropertiesWindow *w = new PropertiesWindow(getCurrentSelections());
-        w->show();
+        if (getCurrentSelections().count() >0)
+        {
+            PropertiesWindow *w = new PropertiesWindow(getCurrentSelections());
+            w->show();
+        }
     });
     addAction(propertiesWindowAction);
 

--- a/libpeony-qt/windows/fm-window.cpp
+++ b/libpeony-qt/windows/fm-window.cpp
@@ -562,6 +562,7 @@ FMWindowFactory *FMWindow::getFactory()
 
 const QString FMWindow::getCurrentUri()
 {
+    //qDebug() << "getCurrentUri in fm-window";
     if (m_tab->getActivePage()) {
         return m_tab->getActivePage()->getCurrentUri();
     }

--- a/libpeony-qt/windows/fm-window.cpp
+++ b/libpeony-qt/windows/fm-window.cpp
@@ -395,7 +395,7 @@ FMWindow::FMWindow(const QString &uri, QWidget *parent) : QMainWindow (parent)
                               "\tYue Lan <lanyue@kylinos.cn>\n"
                               "\tMeihong He <hemeihong@kylinos.cn>\n"
                               "\n"
-                              "Copyright (C): 2019, Tianjin KYLIN Information Technology Co., Ltd."));
+                              "Copyright (C): 2019-2020, Tianjin KYLIN Information Technology Co., Ltd."));
     });
     addAction(aboutAction);
 

--- a/libpeony-qt/windows/fm-window.h
+++ b/libpeony-qt/windows/fm-window.h
@@ -28,6 +28,7 @@
 #include "peony-core_global.h"
 #include "advanced-location-bar.h"
 #include "advance-search-bar.h"
+#include "FMWindowIface.h"
 #include <memory>
 
 #include <QTimer>
@@ -72,27 +73,27 @@ class PreviewPageContainer;
  * the design difficulty. If you plan to develop a file manager application.
  * You should consider wether it is needed.
  */
-class PEONYCORESHARED_EXPORT FMWindow : public QMainWindow
+class PEONYCORESHARED_EXPORT FMWindow : public QMainWindow, public FMWindowIface
 {
     Q_OBJECT
 public:
     explicit FMWindow(const QString &uri = nullptr, QWidget *parent = nullptr);
 
-    const QString getLastNonSearchUri() {return m_last_non_search_location;}
-    const QString getCurrentUri();
-    const QStringList getCurrentSelections();
-    const QStringList getCurrentAllFileUris();
-    const QList<std::shared_ptr<FileInfo>> getCurrentSelectionFileInfos();
-    DirectoryViewContainer *getCurrentPage();
+    const QString getLastNonSearchUri() override {return m_last_non_search_location;}
+    const QString getCurrentUri() override;
+    const QStringList getCurrentSelections() override;
+    const QStringList getCurrentAllFileUris() override;
+    const QList<std::shared_ptr<FileInfo>> getCurrentSelectionFileInfos() override;
+    DirectoryViewContainer *getCurrentPage() override;
 
-    Qt::SortOrder getCurrentSortOrder();
-    int getCurrentSortColumn();
+    Qt::SortOrder getCurrentSortOrder() override;
+    int getCurrentSortColumn() override;
 
-    bool getWindowShowHidden() {return m_show_hidden_file;}
-    bool getWindowUseDefaultNameSortOrder() {return m_use_default_name_sort_order;}
-    bool getWindowSortFolderFirst() {return m_folder_first;}
+    bool getWindowShowHidden() override {return m_show_hidden_file;}
+    bool getWindowUseDefaultNameSortOrder() override {return m_use_default_name_sort_order;}
+    bool getWindowSortFolderFirst() override {return m_folder_first;}
 
-    const QString getCurrentPageViewType();
+    const QString getCurrentPageViewType() override;
 
     QSize sizeHint() const override {return QSize(800, 600);}
 
@@ -119,31 +120,31 @@ Q_SIGNALS:
     void windowSelectionChanged();
 
 public Q_SLOTS:
-    void goToUri(const QString &uri, bool addHistory, bool forceUpdate = false);
-    void addNewTabs(const QStringList &uris);
+    void goToUri(const QString &uri, bool addHistory, bool forceUpdate = false) override;
+    void addNewTabs(const QStringList &uris) override;
 
-    void beginSwitchView(const QString &viewId);
+    void beginSwitchView(const QString &viewId) override;
 
-    void refresh();
-    void forceStopLoading();
-    void advanceSearch();
-    void clearRecord();
-    void searchFilter(QString target_path, QString keyWord, bool search_file_name, bool search_content);
-    void filterUpdate(int type_index=0, int time_index=0, int size_index=0);
+    void refresh() override;
+    void forceStopLoading() override;
+    void advanceSearch() override;
+    void clearRecord() override;
+    void searchFilter(QString target_path, QString keyWord, bool search_file_name, bool search_content) override;
+    void filterUpdate(int type_index=0, int time_index=0, int size_index=0) override;
 
-    void setShowHidden(bool showHidden);
-    void setShowHidden();
-    void setUseDefaultNameSortOrder(bool use);
-    void setSortFolderFirst(bool folderFirst);
+    void setShowHidden(bool showHidden) override;
+    void setShowHidden() override;
+    void setUseDefaultNameSortOrder(bool use) override;
+    void setSortFolderFirst(bool folderFirst) override;
 
-    void onPreviewPageSwitch(const QString &uri);
+    void onPreviewPageSwitch(const QString &uri) override;
 
-    void setCurrentSelectionUris(const QStringList &uris);
-    void setCurrentSortOrder (Qt::SortOrder order);
-    void setCurrentSortColumn (int sortColumn);
+    void setCurrentSelectionUris(const QStringList &uris) override;
+    void setCurrentSortOrder (Qt::SortOrder order) override;
+    void setCurrentSortColumn (int sortColumn) override;
 
-    void editUri(const QString &uri);
-    void editUris(const QStringList &uris);
+    void editUri(const QString &uri) override;
+    void editUris(const QStringList &uris) override;
 
 protected:
     void resizeEvent(QResizeEvent *e) override;

--- a/libpeony-qt/windows/fm-window.h
+++ b/libpeony-qt/windows/fm-window.h
@@ -29,6 +29,7 @@
 #include "advanced-location-bar.h"
 #include "advance-search-bar.h"
 #include "FMWindowIface.h"
+#include "fm-window-factory.h"
 #include <memory>
 
 #include <QTimer>
@@ -78,6 +79,8 @@ class PEONYCORESHARED_EXPORT FMWindow : public QMainWindow, public FMWindowIface
     Q_OBJECT
 public:
     explicit FMWindow(const QString &uri = nullptr, QWidget *parent = nullptr);
+
+    FMWindowFactory *getFactory() override;
 
     const QString getLastNonSearchUri() override {return m_last_non_search_location;}
     const QString getCurrentUri() override;

--- a/libpeony-qt/windows/windows.pri
+++ b/libpeony-qt/windows/windows.pri
@@ -1,6 +1,7 @@
 INCLUDEPATH += $$PWD
 
 HEADERS += \
+    $$PWD/FMWindowIface.h \
     $$PWD/fm-window.h \
     $$PWD/properties-window.h
 

--- a/libpeony-qt/windows/windows.pri
+++ b/libpeony-qt/windows/windows.pri
@@ -2,10 +2,12 @@ INCLUDEPATH += $$PWD
 
 HEADERS += \
     $$PWD/FMWindowIface.h \
+    $$PWD/fm-window-factory.h \
     $$PWD/fm-window.h \
     $$PWD/properties-window.h
 
 SOURCES += \
+    $$PWD/fm-window-factory.cpp \
     $$PWD/fm-window.cpp \
     $$PWD/properties-window.cpp
 

--- a/peony-qt-desktop/desktop-window.cpp
+++ b/peony-qt-desktop/desktop-window.cpp
@@ -39,6 +39,7 @@
 #include "file-move-operation.h"
 #include "file-operation-manager.h"
 #include "file-trash-operation.h"
+#include "properties-window.h"
 
 #include "peony-desktop-application.h"
 #include "singleapplication.h"
@@ -503,6 +504,17 @@ void DesktopWindow::initShortcut() {
         QDesktopServices::openUrl(url);
     });
     addAction(helpAction);
+
+    auto propertiesWindowAction = new QAction(this);
+    propertiesWindowAction->setShortcut(QKeySequence(Qt::ALT + Qt::Key_Return));
+    connect(propertiesWindowAction, &QAction::triggered, this, [=](){
+        if (m_view->getSelections().count() > 0)
+        {
+            PropertiesWindow *w = new PropertiesWindow(m_view->getSelections());
+            w->show();
+        }
+    });
+    addAction(propertiesWindowAction);
 }
 
 void DesktopWindow::availableGeometryChangedProcess(const QRect &geometry) {

--- a/peony-qt-desktop/desktop-window.cpp
+++ b/peony-qt-desktop/desktop-window.cpp
@@ -215,7 +215,7 @@ void DesktopWindow::initGSettings() {
         qDebug() << "bg settings changed:" << key;
         if (key == "pictureFilename") {
             auto bg_path = m_bg_settings->get("pictureFilename").toString();
-            if (!bg_path.startsWith("/")) {
+            if (!QFile::exists(bg_path)) {
                 // use pure color;
                 auto colorString = m_bg_settings->get("primary-color").toString();
                 auto color = QColor(colorString);

--- a/peony-qt-desktop/desktop-window.cpp
+++ b/peony-qt-desktop/desktop-window.cpp
@@ -515,6 +515,39 @@ void DesktopWindow::initShortcut() {
         }
     });
     addAction(propertiesWindowAction);
+
+    auto newFolderAction = new QAction(this);
+    newFolderAction->setShortcut(QKeySequence(Qt::CTRL + Qt::SHIFT + Qt::Key_N));
+    connect(newFolderAction, &QAction::triggered, this, [=](){
+        CreateTemplateOperation op(m_view->getDirectoryUri(), CreateTemplateOperation::EmptyFolder, tr("New Folder"));
+        op.run();
+        auto targetUri = op.target();
+#if QT_VERSION > QT_VERSION_CHECK(5, 12, 0)
+            QTimer::singleShot(500, this, [=](){
+#else
+            QTimer::singleShot(500, [=](){
+#endif
+            this->m_view->scrollToSelection(targetUri);
+        });
+    });
+    addAction(newFolderAction);
+
+    auto refreshAction = new QAction(this);
+    refreshAction->setShortcut(Qt::Key_F5);
+    connect(refreshAction, &QAction::triggered, this, [=](){
+        m_view->refresh();
+    });
+    addAction(refreshAction);
+
+    QAction *editAction = new QAction(m_view);
+    editAction->setShortcuts(QList<QKeySequence>()<<QKeySequence(Qt::ALT + Qt::Key_E)<<Qt::Key_F2);
+    connect(editAction, &QAction::triggered, this, [=](){
+        auto selections = m_view->getSelections();
+        if (selections.count() == 1) {
+            m_view->editUri(selections.first());
+        }
+    });
+    addAction(editAction);
 }
 
 void DesktopWindow::availableGeometryChangedProcess(const QRect &geometry) {

--- a/peony-qt-desktop/main.cpp
+++ b/peony-qt-desktop/main.cpp
@@ -77,7 +77,7 @@ void messageOutput(QtMsgType type, const QMessageLogContext &context, const QStr
 int main(int argc, char *argv[])
 {
     qInstallMessageHandler(messageOutput);
-    PeonyDesktopApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
+    //PeonyDesktopApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
     PeonyDesktopApplication a(argc, argv);
     if (a.isSecondary())
         return 0;

--- a/src/control/control.pri
+++ b/src/control/control.pri
@@ -1,0 +1,13 @@
+INCLUDEPATH += $$PWD
+
+HEADERS += \
+    $$PWD/header-bar.h \
+    $$PWD/navigation-side-bar.h \
+    $$PWD/navigation-tab-bar.h \
+    $$PWD/tab-widget.h
+
+SOURCES += \
+    $$PWD/header-bar.cpp \
+    $$PWD/navigation-side-bar.cpp \
+    $$PWD/navigation-tab-bar.cpp \
+    $$PWD/tab-widget.cpp

--- a/src/control/control.pri
+++ b/src/control/control.pri
@@ -1,12 +1,14 @@
 INCLUDEPATH += $$PWD
 
 HEADERS += \
+    $$PWD/file-label-box.h \
     $$PWD/header-bar.h \
     $$PWD/navigation-side-bar.h \
     $$PWD/navigation-tab-bar.h \
     $$PWD/tab-widget.h
 
 SOURCES += \
+    $$PWD/file-label-box.cpp \
     $$PWD/header-bar.cpp \
     $$PWD/navigation-side-bar.cpp \
     $$PWD/navigation-tab-bar.cpp \

--- a/src/control/control.pri
+++ b/src/control/control.pri
@@ -5,11 +5,17 @@ HEADERS += \
     $$PWD/header-bar.h \
     $$PWD/navigation-side-bar.h \
     $$PWD/navigation-tab-bar.h \
-    $$PWD/tab-widget.h
+    $$PWD/operation-menu.h \
+    $$PWD/sort-type-menu.h \
+    $$PWD/tab-widget.h \
+    $$PWD/view-type-menu.h
 
 SOURCES += \
     $$PWD/file-label-box.cpp \
     $$PWD/header-bar.cpp \
     $$PWD/navigation-side-bar.cpp \
     $$PWD/navigation-tab-bar.cpp \
-    $$PWD/tab-widget.cpp
+    $$PWD/operation-menu.cpp \
+    $$PWD/sort-type-menu.cpp \
+    $$PWD/tab-widget.cpp \
+    $$PWD/view-type-menu.cpp

--- a/src/control/file-label-box.cpp
+++ b/src/control/file-label-box.cpp
@@ -54,6 +54,15 @@ FileLabelBox::FileLabelBox(QWidget *parent) : QListView(parent)
                 //FIXME: edit
                 edit(index);
             });
+
+            menu.addAction(tr("Edit Color"), [=](){
+                QColorDialog d;
+                if (d.exec()) {
+                    auto color = d.selectedColor();
+                    item->setColor(color);
+                }
+            });
+
             auto a = menu.addAction(tr("Delete"), [=](){
                 FileLabelModel::getGlobalModel()->removeLabel(id);
             });

--- a/src/control/file-label-box.cpp
+++ b/src/control/file-label-box.cpp
@@ -21,8 +21,9 @@
  */
 
 #include "file-label-box.h"
+#include "file-label-model.h"
 
 FileLabelBox::FileLabelBox(QWidget *parent) : QListView(parent)
 {
-
+    setModel(FileLabelModel::getGlobalModel());
 }

--- a/src/control/file-label-box.cpp
+++ b/src/control/file-label-box.cpp
@@ -23,7 +23,28 @@
 #include "file-label-box.h"
 #include "file-label-model.h"
 
+#include <QApplication>
+#include <QDebug>
+
+static LabelBoxStyle *global_instance = nullptr;
+
 FileLabelBox::FileLabelBox(QWidget *parent) : QListView(parent)
 {
+    setStyle(LabelBoxStyle::getStyle());
+    viewport()->setStyle(LabelBoxStyle::getStyle());
     setModel(FileLabelModel::getGlobalModel());
+}
+
+//LabelBoxStyle
+LabelBoxStyle *LabelBoxStyle::getStyle()
+{
+    if (!global_instance) {
+        global_instance = new LabelBoxStyle;
+    }
+    return global_instance;
+}
+
+void LabelBoxStyle::drawPrimitive(QStyle::PrimitiveElement element, const QStyleOption *option, QPainter *painter, const QWidget *widget) const
+{
+    return QApplication::style()->drawPrimitive(element, option, painter, widget);
 }

--- a/src/control/file-label-box.cpp
+++ b/src/control/file-label-box.cpp
@@ -20,36 +20,9 @@
  *
  */
 
-#ifndef NAVIGATIONSIDEBAR_H
-#define NAVIGATIONSIDEBAR_H
+#include "file-label-box.h"
 
-#include <QTreeView>
-
-namespace Peony {
-class SideBarModel;
-class SideBarProxyFilterSortModel;
-}
-
-class QPushButton;
-
-class NavigationSideBar : public QTreeView
+FileLabelBox::FileLabelBox(QWidget *parent) : QListView(parent)
 {
-    Q_OBJECT
-public:
-    explicit NavigationSideBar(QWidget *parent = nullptr);
-    bool eventFilter(QObject *obj, QEvent *e);
 
-    void updateGeometries();
-
-Q_SIGNALS:
-    void updateWindowLocationRequest(const QString &uri);
-    void labelButtonClicked(bool checked);
-
-private:
-    Peony::SideBarProxyFilterSortModel *m_proxy_model;
-    Peony::SideBarModel *m_model;
-
-    QPushButton *m_label_button;
-};
-
-#endif // NAVIGATIONSIDEBAR_H
+}

--- a/src/control/file-label-box.h
+++ b/src/control/file-label-box.h
@@ -20,36 +20,19 @@
  *
  */
 
-#ifndef NAVIGATIONSIDEBAR_H
-#define NAVIGATIONSIDEBAR_H
+#ifndef FILELABELBOX_H
+#define FILELABELBOX_H
 
-#include <QTreeView>
+#include <QListView>
 
-namespace Peony {
-class SideBarModel;
-class SideBarProxyFilterSortModel;
-}
-
-class QPushButton;
-
-class NavigationSideBar : public QTreeView
+class FileLabelBox : public QListView
 {
     Q_OBJECT
 public:
-    explicit NavigationSideBar(QWidget *parent = nullptr);
-    bool eventFilter(QObject *obj, QEvent *e);
-
-    void updateGeometries();
+    explicit FileLabelBox(QWidget *parent = nullptr);
 
 Q_SIGNALS:
-    void updateWindowLocationRequest(const QString &uri);
-    void labelButtonClicked(bool checked);
 
-private:
-    Peony::SideBarProxyFilterSortModel *m_proxy_model;
-    Peony::SideBarModel *m_model;
-
-    QPushButton *m_label_button;
 };
 
-#endif // NAVIGATIONSIDEBAR_H
+#endif // FILELABELBOX_H

--- a/src/control/file-label-box.h
+++ b/src/control/file-label-box.h
@@ -24,6 +24,7 @@
 #define FILELABELBOX_H
 
 #include <QListView>
+#include <QProxyStyle>
 
 class FileLabelBox : public QListView
 {
@@ -33,6 +34,16 @@ public:
 
 Q_SIGNALS:
 
+};
+
+class LabelBoxStyle : public QProxyStyle
+{
+    static LabelBoxStyle *getStyle();
+
+    friend class FileLabelBox;
+    LabelBoxStyle() {}
+
+    void drawPrimitive(PrimitiveElement element, const QStyleOption *option, QPainter *painter, const QWidget *widget = nullptr) const override;
 };
 
 #endif // FILELABELBOX_H

--- a/src/control/header-bar.cpp
+++ b/src/control/header-bar.cpp
@@ -40,6 +40,7 @@ HeaderBar::HeaderBar(MainWindow *parent) : QToolBar(parent)
 
     setMovable(false);
 
+
     auto createFolder = new HeaderBarToolButton(this);
     createFolder->setAutoRaise(false);
     createFolder->setToolTip(tr("Create Folder"));
@@ -122,17 +123,20 @@ HeaderBar::HeaderBar(MainWindow *parent) : QToolBar(parent)
     minimize->setIcon(QIcon::fromTheme("window-minimize-symbolic"));
     minimize->setFixedSize(QSize(40, 40));
 
-    QWidget *container = new QWidget(this);
-    container->setContentsMargins(0, 0, 0, 0);
-    QHBoxLayout *hbox = new QHBoxLayout();
-    hbox->setContentsMargins(0, 0, 0, 0);
-    hbox->setSpacing(5);
-    hbox->addWidget(minimize);
-    hbox->addWidget(maximizeAndRestore);
-    hbox->addWidget(close);
-    container->setLayout(hbox);
+//    QWidget *container = new QWidget(this);
+//    container->setContentsMargins(0, 0, 0, 0);
+//    QHBoxLayout *hbox = new QHBoxLayout();
+//    hbox->setContentsMargins(0, 0, 0, 0);
+//    hbox->setSpacing(5);
+//    hbox->addWidget(minimize);
+//    hbox->addWidget(maximizeAndRestore);
+//    hbox->addWidget(close);
+//    container->setLayout(hbox);
 
-    addWidget(container);
+//    addWidget(container);
+    addWidget(minimize);
+    addWidget(maximizeAndRestore);
+    addWidget(close);
 }
 
 void HeaderBar::setLocation(const QString &uri)

--- a/src/control/header-bar.cpp
+++ b/src/control/header-bar.cpp
@@ -40,19 +40,21 @@ HeaderBar::HeaderBar(MainWindow *parent) : QToolBar(parent)
 
     setMovable(false);
 
-
-    auto createFolder = new HeaderBarToolButton(this);
+    auto a = addAction(QIcon::fromTheme("folder-new-symbolic"), tr("Create Folder"), [=](){
+        //FIXME:
+    });
+    auto createFolder = qobject_cast<QToolButton *>(widgetForAction(a));
     createFolder->setAutoRaise(false);
-    createFolder->setToolTip(tr("Create Folder"));
-    createFolder->setIcon(QIcon::fromTheme("folder-new-symbolic"));
     createFolder->setFixedSize(QSize(40, 40));
-    addWidget(createFolder);
+    createFolder->setIconSize(QSize(16, 16));
 
-    auto openTerminal = new HeaderBarToolButton(this);
-    openTerminal->setToolTip(tr("Open Terminal"));
-    openTerminal->setIcon(QIcon::fromTheme("terminal-app-symbolic"));
+    a = addAction(QIcon::fromTheme("terminal-app-symbolic"), tr("Open Terminal"), [=](){
+        //FIXME:
+    });
+    auto openTerminal = qobject_cast<QToolButton *>(widgetForAction(a));
+    openTerminal->setAutoRaise(false);
     openTerminal->setFixedSize(QSize(40, 40));
-    addWidget(openTerminal);
+    openTerminal->setIconSize(QSize(16, 16));
 
     addSeparator();
 
@@ -73,70 +75,73 @@ HeaderBar::HeaderBar(MainWindow *parent) : QToolBar(parent)
     auto locationBar = new Peony::AdvancedLocationBar(this);
     addWidget(locationBar);
 
-    auto search = new HeaderBarToolButton(this);
-    search->setToolTip(tr("Search"));
-    search->setIcon(QIcon::fromTheme("edit-find-symbolic"));
+    addSeparator();
+    a = addAction(QIcon::fromTheme("edit-find-symbolic"), tr("Search"), [=](){
+        //FIXME:
+    });
+    auto search = qobject_cast<QToolButton *>(widgetForAction(a));
+    search->setAutoRaise(false);
     search->setFixedSize(QSize(40, 40));
-    addSeparator();
-    addWidget(search);
+    setIconSize(QSize(16, 16));
 
     addSeparator();
 
-    auto viewType = new HeaderBarToolButton(this);
-    viewType->setToolTip(tr("View Type"));
-    viewType->setIcon(QIcon::fromTheme("view-grid-symbolic"));
+    a = addAction(QIcon::fromTheme("view-grid-symbolic"), tr("View Type"), [=](){
+        //FIXME:
+    });
+    auto viewType = qobject_cast<QToolButton *>(widgetForAction(a));
+    viewType->setAutoRaise(false);
     viewType->setFixedSize(QSize(57, 40));
+    viewType->setIconSize(QSize(16, 16));
     viewType->setPopupMode(QToolButton::MenuButtonPopup);
-    addWidget(viewType);
 
-    auto sortType = new HeaderBarToolButton(this);
-    sortType->setToolTip(tr("Sort Type"));
-    sortType->setIcon(QIcon::fromTheme("view-sort-descending-symbolic"));
+    a = addAction(QIcon::fromTheme("view-sort-descending-symbolic"), tr("Sort Type"), [=](){
+        //FIXME:
+    });
+    auto sortType = qobject_cast<QToolButton *>(widgetForAction(a));
+    sortType->setAutoRaise(false);
     sortType->setFixedSize(QSize(57, 40));
+    sortType->setIconSize(QSize(16, 16));
     sortType->setPopupMode(QToolButton::MenuButtonPopup);
-    addWidget(sortType);
 
-    auto popMenu = new HeaderBarToolButton(this);
-    popMenu->setToolTip(tr("Option"));
-    popMenu->setIcon(QIcon::fromTheme("open-menu-symbolic"));
-    popMenu->setFixedSize(QSize(40, 40));
-    addWidget(popMenu);
+    a = addAction(QIcon::fromTheme("open-menu-symbolic"), tr("Option"), [=](){
+        //FIXME:
+    });
+    auto popMenu = qobject_cast<QToolButton *>(widgetForAction(a));
+    popMenu->setAutoRaise(false);
+    popMenu->setFixedSize(QSize(57, 40));
+    popMenu->setIconSize(QSize(16, 16));
+    popMenu->setPopupMode(QToolButton::MenuButtonPopup);
 
     //minimize, maximize and close
-    auto close = new HeaderBarToolButton(this);
-    close->setToolTip(tr("Close"));
-    close->setIcon(QIcon::fromTheme("window-close-symbolic"));
-    close->setFixedSize(QSize(40, 40));
-    connect(close, &QToolButton::clicked, this, [=](){
-        m_window->close();
+    a = addAction(QIcon::fromTheme("window-minimize-symbolic"), tr("Minimize"), [=](){
+        //FIXME:
     });
+    auto minimize = qobject_cast<QToolButton *>(widgetForAction(a));
+    minimize->setAutoRaise(false);
+    minimize->setFixedSize(QSize(40, 40));
+    minimize->setIconSize(QSize(16, 16));
 
     //window-maximize-symbolic
     //window-restore-symbolic
-    auto maximizeAndRestore = new HeaderBarToolButton(this);
-    maximizeAndRestore->setToolTip(tr("Maximize"));
-    maximizeAndRestore->setIcon(QIcon::fromTheme("window-maximize-symbolic"));
+    a = addAction(QIcon::fromTheme("window-maximize-symbolic"), nullptr, [=](){
+        //FIXME:
+    });
+    auto maximizeAndRestore = qobject_cast<QToolButton *>(widgetForAction(a));
+    maximizeAndRestore->setAutoRaise(false);
     maximizeAndRestore->setFixedSize(QSize(40, 40));
+    maximizeAndRestore->setIconSize(QSize(16, 16));
 
-    auto minimize = new HeaderBarToolButton(this);
-    minimize->setToolTip(tr("Minimize"));
-    minimize->setIcon(QIcon::fromTheme("window-minimize-symbolic"));
-    minimize->setFixedSize(QSize(40, 40));
+    a = addAction(QIcon::fromTheme("window-close-symbolic"), tr("Close"), [=](){
 
-//    QWidget *container = new QWidget(this);
-//    container->setContentsMargins(0, 0, 0, 0);
-//    QHBoxLayout *hbox = new QHBoxLayout();
-//    hbox->setContentsMargins(0, 0, 0, 0);
-//    hbox->setSpacing(5);
-//    hbox->addWidget(minimize);
-//    hbox->addWidget(maximizeAndRestore);
-//    hbox->addWidget(close);
-//    container->setLayout(hbox);
-
-//    addWidget(container);
-    addWidget(minimize);
-    addWidget(maximizeAndRestore);
-    addWidget(close);
+    });
+    auto close = qobject_cast<QToolButton *>(widgetForAction(a));
+    close->setAutoRaise(false);
+    close->setFixedSize(QSize(40, 40));
+    close->setIconSize(QSize(16, 16));
+    connect(close, &QToolButton::clicked, this, [=](){
+        m_window->close();
+    });
 }
 
 void HeaderBar::setLocation(const QString &uri)

--- a/src/control/header-bar.cpp
+++ b/src/control/header-bar.cpp
@@ -11,8 +11,9 @@ HeaderBar::HeaderBar(MainWindow *parent) : QToolBar(parent)
     setStyleSheet(".HeaderBar{"
                   "background-color: transparent;"
                   "border: 0px solid transparent;"
-                  "margin: 4, 5, 4, 5;"
+                  "margin: 4px 5px 4px 5px;"
                   "};");
+
     setMovable(false);
 
     auto createFolder = new HeaderBarToolButton(this);

--- a/src/control/header-bar.cpp
+++ b/src/control/header-bar.cpp
@@ -26,8 +26,12 @@
 #include <QHBoxLayout>
 #include <advanced-location-bar.h>
 
+static HeaderBarStyle *global_instance = nullptr;
+
 HeaderBar::HeaderBar(MainWindow *parent) : QToolBar(parent)
 {
+    setStyle(HeaderBarStyle::getStyle());
+
     m_window = parent;
     //disable default menu
     setContextMenuPolicy(Qt::CustomContextMenu);
@@ -160,4 +164,39 @@ HeaderBarToolButton::HeaderBarToolButton(QWidget *parent) : QToolButton(parent)
 HeadBarPushButton::HeadBarPushButton(QWidget *parent) : QPushButton(parent)
 {
     setIconSize(QSize(16, 16));
+}
+
+//HeaderBarStyle
+HeaderBarStyle *HeaderBarStyle::getStyle()
+{
+    if (!global_instance) {
+        global_instance = new HeaderBarStyle;
+    }
+    return global_instance;
+}
+
+int HeaderBarStyle::pixelMetric(QStyle::PixelMetric metric, const QStyleOption *option, const QWidget *widget) const
+{
+    switch (metric) {
+    case PM_ToolBarIconSize:
+        return 16;
+    case PM_ToolBarSeparatorExtent:
+        return 6;
+    case PM_ToolBarItemSpacing: {
+        return 2;
+    }
+    case PM_ToolBarItemMargin:
+    case PM_ToolBarFrameWidth:
+        return 0;
+    default:
+        return QProxyStyle::pixelMetric(metric, option, widget);
+    }
+}
+
+void HeaderBarStyle::drawPrimitive(QStyle::PrimitiveElement element, const QStyleOption *option, QPainter *painter, const QWidget *widget) const
+{
+    if (element == PE_IndicatorToolBarSeparator) {
+        return;
+    }
+    return QProxyStyle::drawPrimitive(element, option, painter, widget);
 }

--- a/src/control/header-bar.cpp
+++ b/src/control/header-bar.cpp
@@ -35,7 +35,7 @@ HeaderBar::HeaderBar(MainWindow *parent) : QToolBar(parent)
     m_window = parent;
     //disable default menu
     setContextMenuPolicy(Qt::CustomContextMenu);
-    setAttribute(Qt::WA_OpaquePaintEvent);
+    //setAttribute(Qt::WA_OpaquePaintEvent);
     setStyleSheet(".HeaderBar{"
                   "background-color: transparent;"
                   "border: 0px solid transparent;"

--- a/src/control/header-bar.cpp
+++ b/src/control/header-bar.cpp
@@ -60,7 +60,7 @@ HeaderBar::HeaderBar(MainWindow *parent) : QToolBar(parent)
     openTerminal->setFixedSize(QSize(40, 40));
     openTerminal->setIconSize(QSize(16, 16));
 
-    addSeparator();
+    addSpacing(9);
 
     auto goBack = new HeadBarPushButton(this);
     goBack->setToolTip(tr("Go Back"));
@@ -74,12 +74,12 @@ HeaderBar::HeaderBar(MainWindow *parent) : QToolBar(parent)
     goForward->setIcon(QIcon::fromTheme("go-next-symbolic"));
     addWidget(goForward);
 
-    addSeparator();
+    addSpacing(9);
 
     auto locationBar = new Peony::AdvancedLocationBar(this);
     addWidget(locationBar);
 
-    addSeparator();
+    addSpacing(9);
     a = addAction(QIcon::fromTheme("edit-find-symbolic"), tr("Search"), [=](){
         //FIXME:
     });
@@ -88,7 +88,7 @@ HeaderBar::HeaderBar(MainWindow *parent) : QToolBar(parent)
     search->setFixedSize(QSize(40, 40));
     setIconSize(QSize(16, 16));
 
-    addSeparator();
+    addSpacing(9);
 
     a = addAction(QIcon::fromTheme("view-grid-symbolic"), tr("View Type"), [=](){
         //FIXME:
@@ -148,6 +148,13 @@ HeaderBar::HeaderBar(MainWindow *parent) : QToolBar(parent)
     });
 }
 
+void HeaderBar::addSpacing(int pixel)
+{
+    for (int i = 0; i < pixel; i++) {
+        addSeparator();
+    }
+}
+
 void HeaderBar::setLocation(const QString &uri)
 {
     //FIXME:
@@ -181,9 +188,9 @@ int HeaderBarStyle::pixelMetric(QStyle::PixelMetric metric, const QStyleOption *
     case PM_ToolBarIconSize:
         return 16;
     case PM_ToolBarSeparatorExtent:
-        return 6;
+        return 1;
     case PM_ToolBarItemSpacing: {
-        return 2;
+        return 1;
     }
     case PM_ToolBarItemMargin:
     case PM_ToolBarFrameWidth:

--- a/src/control/header-bar.cpp
+++ b/src/control/header-bar.cpp
@@ -1,3 +1,25 @@
+/*
+ * Peony-Qt
+ *
+ * Copyright (C) 2020, Tianjin KYLIN Information Technology Co., Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Authors: Yue Lan <lanyue@kylinos.cn>
+ *
+ */
+
 #include "header-bar.h"
 #include "main-window.h"
 
@@ -7,6 +29,8 @@
 HeaderBar::HeaderBar(MainWindow *parent) : QToolBar(parent)
 {
     m_window = parent;
+    //disable default menu
+    setContextMenuPolicy(Qt::CustomContextMenu);
     setAttribute(Qt::WA_OpaquePaintEvent);
     setStyleSheet(".HeaderBar{"
                   "background-color: transparent;"
@@ -17,6 +41,7 @@ HeaderBar::HeaderBar(MainWindow *parent) : QToolBar(parent)
     setMovable(false);
 
     auto createFolder = new HeaderBarToolButton(this);
+    createFolder->setAutoRaise(false);
     createFolder->setToolTip(tr("Create Folder"));
     createFolder->setIcon(QIcon::fromTheme("folder-new-symbolic"));
     createFolder->setFixedSize(QSize(40, 40));
@@ -47,12 +72,12 @@ HeaderBar::HeaderBar(MainWindow *parent) : QToolBar(parent)
     auto locationBar = new Peony::AdvancedLocationBar(this);
     addWidget(locationBar);
 
-    auto serach = new HeaderBarToolButton(this);
-    serach->setToolTip(tr("Search"));
-    serach->setIcon(QIcon::fromTheme("edit-find-symbolic"));
-    serach->setFixedSize(QSize(40, 40));
+    auto search = new HeaderBarToolButton(this);
+    search->setToolTip(tr("Search"));
+    search->setIcon(QIcon::fromTheme("edit-find-symbolic"));
+    search->setFixedSize(QSize(40, 40));
     addSeparator();
-    addWidget(serach);
+    addWidget(search);
 
     addSeparator();
 
@@ -81,6 +106,9 @@ HeaderBar::HeaderBar(MainWindow *parent) : QToolBar(parent)
     close->setToolTip(tr("Close"));
     close->setIcon(QIcon::fromTheme("window-close-symbolic"));
     close->setFixedSize(QSize(40, 40));
+    connect(close, &QToolButton::clicked, this, [=](){
+        m_window->close();
+    });
 
     //window-maximize-symbolic
     //window-restore-symbolic
@@ -96,7 +124,7 @@ HeaderBar::HeaderBar(MainWindow *parent) : QToolBar(parent)
 
     QWidget *container = new QWidget(this);
     container->setContentsMargins(0, 0, 0, 0);
-    QHBoxLayout *hbox = new QHBoxLayout(container);
+    QHBoxLayout *hbox = new QHBoxLayout();
     hbox->setContentsMargins(0, 0, 0, 0);
     hbox->setSpacing(5);
     hbox->addWidget(minimize);
@@ -115,6 +143,7 @@ void HeaderBar::setLocation(const QString &uri)
 //HeaderBarToolButton
 HeaderBarToolButton::HeaderBarToolButton(QWidget *parent) : QToolButton(parent)
 {
+    setAutoRaise(false);
     setIconSize(QSize(16, 16));
 }
 

--- a/src/control/header-bar.cpp
+++ b/src/control/header-bar.cpp
@@ -1,0 +1,124 @@
+#include "header-bar.h"
+#include "main-window.h"
+
+#include <QHBoxLayout>
+#include <advanced-location-bar.h>
+
+HeaderBar::HeaderBar(MainWindow *parent) : QToolBar(parent)
+{
+    m_window = parent;
+    setAttribute(Qt::WA_OpaquePaintEvent);
+    setStyleSheet(".HeaderBar{"
+                  "background-color: transparent;"
+                  "border: 0px solid transparent;"
+                  "margin: 4, 5, 4, 5;"
+                  "};");
+    setMovable(false);
+
+    auto createFolder = new HeaderBarToolButton(this);
+    createFolder->setToolTip(tr("Create Folder"));
+    createFolder->setIcon(QIcon::fromTheme("folder-new-symbolic"));
+    createFolder->setFixedSize(QSize(40, 40));
+    addWidget(createFolder);
+
+    auto openTerminal = new HeaderBarToolButton(this);
+    openTerminal->setToolTip(tr("Open Terminal"));
+    openTerminal->setIcon(QIcon::fromTheme("terminal-app-symbolic"));
+    openTerminal->setFixedSize(QSize(40, 40));
+    addWidget(openTerminal);
+
+    addSeparator();
+
+    auto goBack = new HeadBarPushButton(this);
+    goBack->setToolTip(tr("Go Back"));
+    goBack->setFixedSize(QSize(36, 28));
+    goBack->setIcon(QIcon::fromTheme("go-previous-symbolic"));
+    addWidget(goBack);
+
+    auto goForward = new HeadBarPushButton(this);
+    goForward->setToolTip(tr("Go Forward"));
+    goForward->setFixedSize(QSize(36, 28));
+    goForward->setIcon(QIcon::fromTheme("go-next-symbolic"));
+    addWidget(goForward);
+
+    addSeparator();
+
+    auto locationBar = new Peony::AdvancedLocationBar(this);
+    addWidget(locationBar);
+
+    auto serach = new HeaderBarToolButton(this);
+    serach->setToolTip(tr("Search"));
+    serach->setIcon(QIcon::fromTheme("edit-find-symbolic"));
+    serach->setFixedSize(QSize(40, 40));
+    addSeparator();
+    addWidget(serach);
+
+    addSeparator();
+
+    auto viewType = new HeaderBarToolButton(this);
+    viewType->setToolTip(tr("View Type"));
+    viewType->setIcon(QIcon::fromTheme("view-grid-symbolic"));
+    viewType->setFixedSize(QSize(57, 40));
+    viewType->setPopupMode(QToolButton::MenuButtonPopup);
+    addWidget(viewType);
+
+    auto sortType = new HeaderBarToolButton(this);
+    sortType->setToolTip(tr("Sort Type"));
+    sortType->setIcon(QIcon::fromTheme("view-sort-descending-symbolic"));
+    sortType->setFixedSize(QSize(57, 40));
+    sortType->setPopupMode(QToolButton::MenuButtonPopup);
+    addWidget(sortType);
+
+    auto popMenu = new HeaderBarToolButton(this);
+    popMenu->setToolTip(tr("Option"));
+    popMenu->setIcon(QIcon::fromTheme("open-menu-symbolic"));
+    popMenu->setFixedSize(QSize(40, 40));
+    addWidget(popMenu);
+
+    //minimize, maximize and close
+    auto close = new HeaderBarToolButton(this);
+    close->setToolTip(tr("Close"));
+    close->setIcon(QIcon::fromTheme("window-close-symbolic"));
+    close->setFixedSize(QSize(40, 40));
+
+    //window-maximize-symbolic
+    //window-restore-symbolic
+    auto maximizeAndRestore = new HeaderBarToolButton(this);
+    maximizeAndRestore->setToolTip(tr("Maximize"));
+    maximizeAndRestore->setIcon(QIcon::fromTheme("window-maximize-symbolic"));
+    maximizeAndRestore->setFixedSize(QSize(40, 40));
+
+    auto minimize = new HeaderBarToolButton(this);
+    minimize->setToolTip(tr("Minimize"));
+    minimize->setIcon(QIcon::fromTheme("window-minimize-symbolic"));
+    minimize->setFixedSize(QSize(40, 40));
+
+    QWidget *container = new QWidget(this);
+    container->setContentsMargins(0, 0, 0, 0);
+    QHBoxLayout *hbox = new QHBoxLayout(container);
+    hbox->setContentsMargins(0, 0, 0, 0);
+    hbox->setSpacing(5);
+    hbox->addWidget(minimize);
+    hbox->addWidget(maximizeAndRestore);
+    hbox->addWidget(close);
+    container->setLayout(hbox);
+
+    addWidget(container);
+}
+
+void HeaderBar::setLocation(const QString &uri)
+{
+    //FIXME:
+}
+
+//HeaderBarToolButton
+HeaderBarToolButton::HeaderBarToolButton(QWidget *parent) : QToolButton(parent)
+{
+    setIconSize(QSize(16, 16));
+}
+
+//HeadBarPushButton
+HeadBarPushButton::HeadBarPushButton(QWidget *parent) : QPushButton(parent)
+{
+    setIconSize(QSize(16, 16));
+}

--- a/src/control/header-bar.cpp
+++ b/src/control/header-bar.cpp
@@ -290,9 +290,6 @@ int HeaderBarStyle::pixelMetric(QStyle::PixelMetric metric, const QStyleOption *
     case PM_ToolBarItemSpacing: {
         return 1;
     }
-    case PM_ToolBarItemMargin:
-    case PM_ToolBarFrameWidth:
-        return 0;
     default:
         return QProxyStyle::pixelMetric(metric, option, widget);
     }

--- a/src/control/header-bar.cpp
+++ b/src/control/header-bar.cpp
@@ -25,6 +25,7 @@
 
 #include "view-type-menu.h"
 #include "sort-type-menu.h"
+#include "operation-menu.h"
 
 #include <QHBoxLayout>
 #include <advanced-location-bar.h>
@@ -124,6 +125,9 @@ HeaderBar::HeaderBar(MainWindow *parent) : QToolBar(parent)
     popMenu->setFixedSize(QSize(57, 40));
     popMenu->setIconSize(QSize(16, 16));
     popMenu->setPopupMode(QToolButton::InstantPopup);
+
+    m_operation_menu = new OperationMenu(m_window, this);
+    popMenu->setMenu(m_operation_menu);
 
     //minimize, maximize and close
     a = addAction(QIcon::fromTheme("window-minimize-symbolic"), tr("Minimize"), [=](){

--- a/src/control/header-bar.cpp
+++ b/src/control/header-bar.cpp
@@ -210,10 +210,12 @@ HeaderBar::HeaderBar(MainWindow *parent) : QToolBar(parent)
 
 void HeaderBar::searchButtonClicked()
 {
-    m_search_button->setCheckable(true);
-    m_search_button->setChecked(true);
-    m_search_button->setDown(true);
-    m_location_bar->switchEditMode();
+    m_search_mode = ! m_search_mode;
+    //qDebug() << "searchButtonClicked" <<m_search_mode;
+    m_search_button->setCheckable(m_search_mode);
+    m_search_button->setChecked(m_search_mode);
+    m_search_button->setDown(m_search_mode);
+    m_location_bar->switchEditMode(m_search_mode);
 }
 
 void HeaderBar::addSpacing(int pixel)

--- a/src/control/header-bar.cpp
+++ b/src/control/header-bar.cpp
@@ -23,6 +23,9 @@
 #include "header-bar.h"
 #include "main-window.h"
 
+#include "view-type-menu.h"
+#include "sort-type-menu.h"
+
 #include <QHBoxLayout>
 #include <advanced-location-bar.h>
 
@@ -90,32 +93,37 @@ HeaderBar::HeaderBar(MainWindow *parent) : QToolBar(parent)
 
     addSpacing(9);
 
-    a = addAction(QIcon::fromTheme("view-grid-symbolic"), tr("View Type"), [=](){
-        //FIXME:
-    });
+    a = addAction(QIcon::fromTheme("view-grid-symbolic"), tr("View Type"));
     auto viewType = qobject_cast<QToolButton *>(widgetForAction(a));
     viewType->setAutoRaise(false);
     viewType->setFixedSize(QSize(57, 40));
     viewType->setIconSize(QSize(16, 16));
-    viewType->setPopupMode(QToolButton::MenuButtonPopup);
+    viewType->setPopupMode(QToolButton::InstantPopup);
 
-    a = addAction(QIcon::fromTheme("view-sort-descending-symbolic"), tr("Sort Type"), [=](){
-        //FIXME:
+    m_view_type_menu = new ViewTypeMenu(viewType);
+    viewType->setMenu(m_view_type_menu);
+
+    connect(m_view_type_menu, &ViewTypeMenu::switchViewRequest, this, [=](const QString &id, const QIcon &icon){
+        viewType->setText(id);
+        viewType->setIcon(icon);
     });
+
+    a = addAction(QIcon::fromTheme("view-sort-descending-symbolic"), tr("Sort Type"));
     auto sortType = qobject_cast<QToolButton *>(widgetForAction(a));
     sortType->setAutoRaise(false);
     sortType->setFixedSize(QSize(57, 40));
     sortType->setIconSize(QSize(16, 16));
-    sortType->setPopupMode(QToolButton::MenuButtonPopup);
+    sortType->setPopupMode(QToolButton::InstantPopup);
 
-    a = addAction(QIcon::fromTheme("open-menu-symbolic"), tr("Option"), [=](){
-        //FIXME:
-    });
+    m_sort_type_menu = new SortTypeMenu(this);
+    sortType->setMenu(m_sort_type_menu);
+
+    a = addAction(QIcon::fromTheme("open-menu-symbolic"), tr("Option"));
     auto popMenu = qobject_cast<QToolButton *>(widgetForAction(a));
     popMenu->setAutoRaise(false);
     popMenu->setFixedSize(QSize(57, 40));
     popMenu->setIconSize(QSize(16, 16));
-    popMenu->setPopupMode(QToolButton::MenuButtonPopup);
+    popMenu->setPopupMode(QToolButton::InstantPopup);
 
     //minimize, maximize and close
     a = addAction(QIcon::fromTheme("window-minimize-symbolic"), tr("Minimize"), [=](){

--- a/src/control/header-bar.cpp
+++ b/src/control/header-bar.cpp
@@ -115,6 +115,7 @@ HeaderBar::HeaderBar(MainWindow *parent) : QToolBar(parent)
     connect(m_view_type_menu, &ViewTypeMenu::switchViewRequest, this, [=](const QString &id, const QIcon &icon){
         viewType->setText(id);
         viewType->setIcon(icon);
+        this->viewTypeChangeRequest(id);
     });
 
     a = addAction(QIcon::fromTheme("view-sort-descending-symbolic"), tr("Sort Type"));

--- a/src/control/header-bar.cpp
+++ b/src/control/header-bar.cpp
@@ -63,6 +63,8 @@ HeaderBar::HeaderBar(MainWindow *parent) : QToolBar(parent)
     createFolder->setFixedSize(QSize(40, 40));
     createFolder->setIconSize(QSize(16, 16));
 
+    addSpacing(2);
+
     a = addAction(QIcon::fromTheme("terminal-app-symbolic"), tr("Open Terminal"), [=](){
         //FIXME:
     });
@@ -130,6 +132,8 @@ HeaderBar::HeaderBar(MainWindow *parent) : QToolBar(parent)
         this->viewTypeChangeRequest(id);
     });
 
+    addSpacing(2);
+
     a = addAction(QIcon::fromTheme("view-sort-ascending-symbolic"), tr("Sort Type"));
     auto sortType = qobject_cast<QToolButton *>(widgetForAction(a));
     sortType->setAutoRaise(false);
@@ -154,6 +158,8 @@ HeaderBar::HeaderBar(MainWindow *parent) : QToolBar(parent)
         m_sort_type_menu->setSortOrder(m_window->getCurrentSortOrder());
     });
 
+    addSpacing(2);
+
     a = addAction(QIcon::fromTheme("open-menu-symbolic"), tr("Option"));
     auto popMenu = qobject_cast<QToolButton *>(widgetForAction(a));
     popMenu->setAutoRaise(false);
@@ -164,6 +170,8 @@ HeaderBar::HeaderBar(MainWindow *parent) : QToolBar(parent)
     m_operation_menu = new OperationMenu(m_window, this);
     popMenu->setMenu(m_operation_menu);
 
+    addSpacing(2);
+
     //minimize, maximize and close
     a = addAction(QIcon::fromTheme("window-minimize-symbolic"), tr("Minimize"), [=](){
         m_window->showMinimized();
@@ -172,6 +180,8 @@ HeaderBar::HeaderBar(MainWindow *parent) : QToolBar(parent)
     minimize->setAutoRaise(false);
     minimize->setFixedSize(QSize(40, 40));
     minimize->setIconSize(QSize(16, 16));
+
+    addSpacing(2);
 
     //window-maximize-symbolic
     //window-restore-symbolic
@@ -183,6 +193,8 @@ HeaderBar::HeaderBar(MainWindow *parent) : QToolBar(parent)
     maximizeAndRestore->setAutoRaise(false);
     maximizeAndRestore->setFixedSize(QSize(40, 40));
     maximizeAndRestore->setIconSize(QSize(16, 16));
+
+    addSpacing(2);
 
     a = addAction(QIcon::fromTheme("window-close-symbolic"), tr("Close"), [=](){
         m_window->close();

--- a/src/control/header-bar.cpp
+++ b/src/control/header-bar.cpp
@@ -208,6 +208,16 @@ void HeaderBar::setLocation(const QString &uri)
     m_location_bar->updateLocation(uri);
 }
 
+void HeaderBar::startEdit()
+{
+    m_location_bar->startEdit();
+}
+
+void HeaderBar::finishEdit()
+{
+    m_location_bar->finishEdit();
+}
+
 void HeaderBar::updateIcons()
 {
     qDebug()<<m_window->getCurrentUri();

--- a/src/control/header-bar.cpp
+++ b/src/control/header-bar.cpp
@@ -106,13 +106,13 @@ HeaderBar::HeaderBar(MainWindow *parent) : QToolBar(parent)
     connect(m_location_bar, &Peony::AdvancedLocationBar::updateWindowLocationRequest, this, &HeaderBar::updateLocationRequest);
 
     addSpacing(9);
-    a = addAction(QIcon::fromTheme("edit-find-symbolic"), tr("Search"), [=](){
-        //FIXME:
-    });
+    a = addAction(QIcon::fromTheme("edit-find-symbolic"), tr("Search"));
+    connect(a, &QAction::triggered, this, &HeaderBar::searchButtonClicked);
     auto search = qobject_cast<QToolButton *>(widgetForAction(a));
     search->setAutoRaise(false);
     search->setFixedSize(QSize(40, 40));
     setIconSize(QSize(16, 16));
+    m_search_button = search;
 
     addSpacing(9);
 
@@ -206,6 +206,14 @@ HeaderBar::HeaderBar(MainWindow *parent) : QToolBar(parent)
     connect(close, &QToolButton::clicked, this, [=](){
         m_window->close();
     });
+}
+
+void HeaderBar::searchButtonClicked()
+{
+    m_search_button->setCheckable(true);
+    m_search_button->setChecked(true);
+    m_search_button->setDown(true);
+    m_location_bar->switchEditMode();
 }
 
 void HeaderBar::addSpacing(int pixel)

--- a/src/control/header-bar.h
+++ b/src/control/header-bar.h
@@ -1,0 +1,44 @@
+#ifndef HEADERBAR_H
+#define HEADERBAR_H
+
+#include <QToolBar>
+#include <QToolButton>
+#include <QPushButton>
+
+class MainWindow;
+
+class HeaderBar : public QToolBar
+{
+    friend class MainWindow;
+    Q_OBJECT
+private:
+    explicit HeaderBar(MainWindow *parent = nullptr);
+
+Q_SIGNALS:
+    void updateLocationRequest(const QString &uri);
+
+private Q_SLOTS:
+    void setLocation(const QString &uri);
+
+private:
+    const QString m_uri;
+    MainWindow *m_window;
+};
+
+class HeaderBarToolButton : public QToolButton
+{
+    friend class HeaderBar;
+    friend class MainWindow;
+    Q_OBJECT;
+    explicit HeaderBarToolButton(QWidget *parent = nullptr);
+};
+
+class HeadBarPushButton : public QPushButton
+{
+    friend class HeaderBar;
+    friend class MainWindow;
+    Q_OBJECT
+    explicit HeadBarPushButton(QWidget *parent = nullptr);
+};
+
+#endif // HEADERBAR_H

--- a/src/control/header-bar.h
+++ b/src/control/header-bar.h
@@ -40,6 +40,9 @@ private:
 Q_SIGNALS:
     void updateLocationRequest(const QString &uri);
 
+protected:
+    void addSpacing(int pixel);
+
 private Q_SLOTS:
     void setLocation(const QString &uri);
 

--- a/src/control/header-bar.h
+++ b/src/control/header-bar.h
@@ -26,6 +26,7 @@
 #include <QToolBar>
 #include <QToolButton>
 #include <QPushButton>
+#include <QProxyStyle>
 
 class MainWindow;
 
@@ -61,6 +62,18 @@ class HeadBarPushButton : public QPushButton
     friend class MainWindow;
     Q_OBJECT
     explicit HeadBarPushButton(QWidget *parent = nullptr);
+};
+
+class HeaderBarStyle : public QProxyStyle
+{
+    friend class HeaderBar;
+    static HeaderBarStyle *getStyle();
+
+    HeaderBarStyle() {}
+
+    int pixelMetric(PixelMetric metric, const QStyleOption *option = nullptr, const QWidget *widget = nullptr) const override;
+
+    void drawPrimitive(PrimitiveElement element, const QStyleOption *option, QPainter *painter, const QWidget *widget = nullptr) const override;
 };
 
 #endif // HEADERBAR_H

--- a/src/control/header-bar.h
+++ b/src/control/header-bar.h
@@ -29,6 +29,9 @@
 #include <QProxyStyle>
 
 class MainWindow;
+class ViewTypeMenu;
+class SortTypeMenu;
+class OperationMenu;
 
 class HeaderBar : public QToolBar
 {
@@ -49,6 +52,10 @@ private Q_SLOTS:
 private:
     const QString m_uri;
     MainWindow *m_window;
+
+    ViewTypeMenu *m_view_type_menu;
+    SortTypeMenu *m_sort_type_menu;
+    OperationMenu *m_operation_menu;
 };
 
 class HeaderBarToolButton : public QToolButton

--- a/src/control/header-bar.h
+++ b/src/control/header-bar.h
@@ -33,6 +33,10 @@ class ViewTypeMenu;
 class SortTypeMenu;
 class OperationMenu;
 
+namespace Peony {
+class AdvancedLocationBar;
+}
+
 class HeaderBar : public QToolBar
 {
     friend class MainWindow;
@@ -41,21 +45,26 @@ private:
     explicit HeaderBar(MainWindow *parent = nullptr);
 
 Q_SIGNALS:
-    void updateLocationRequest(const QString &uri);
+    void updateLocationRequest(const QString &uri, bool addHistory = true, bool force = true);
 
 protected:
     void addSpacing(int pixel);
 
 private Q_SLOTS:
     void setLocation(const QString &uri);
+    void updateIcons();
 
 private:
     const QString m_uri;
     MainWindow *m_window;
 
+    Peony::AdvancedLocationBar *m_location_bar;
+
     ViewTypeMenu *m_view_type_menu;
     SortTypeMenu *m_sort_type_menu;
     OperationMenu *m_operation_menu;
+
+    QToolButton *m_maximize_restore_button;
 };
 
 class HeaderBarToolButton : public QToolButton
@@ -83,6 +92,7 @@ class HeaderBarStyle : public QProxyStyle
 
     int pixelMetric(PixelMetric metric, const QStyleOption *option = nullptr, const QWidget *widget = nullptr) const override;
 
+    void drawComplexControl(ComplexControl control, const QStyleOptionComplex *option, QPainter *painter, const QWidget *widget = nullptr) const override;
     void drawPrimitive(PrimitiveElement element, const QStyleOption *option, QPainter *painter, const QWidget *widget = nullptr) const override;
 };
 

--- a/src/control/header-bar.h
+++ b/src/control/header-bar.h
@@ -46,6 +46,7 @@ private:
 
 Q_SIGNALS:
     void updateLocationRequest(const QString &uri, bool addHistory = true, bool force = true);
+    void viewTypeChangeRequest(const QString &viewId);
 
 protected:
     void addSpacing(int pixel);

--- a/src/control/header-bar.h
+++ b/src/control/header-bar.h
@@ -54,6 +54,7 @@ protected:
 private Q_SLOTS:
     void setLocation(const QString &uri);
     void updateIcons();
+    void updateMaximizeState();
 
 private:
     const QString m_uri;
@@ -65,6 +66,8 @@ private:
     SortTypeMenu *m_sort_type_menu;
     OperationMenu *m_operation_menu;
 
+    QPushButton *m_go_back;
+    QPushButton *m_go_forward;
     QToolButton *m_maximize_restore_button;
 };
 

--- a/src/control/header-bar.h
+++ b/src/control/header-bar.h
@@ -55,6 +55,8 @@ private Q_SLOTS:
     void setLocation(const QString &uri);
     void updateIcons();
     void updateMaximizeState();
+    void startEdit();
+    void finishEdit();
 
 private:
     const QString m_uri;

--- a/src/control/header-bar.h
+++ b/src/control/header-bar.h
@@ -73,6 +73,8 @@ private:
     QPushButton *m_go_forward;
     QToolButton *m_maximize_restore_button;
     QToolButton *m_search_button;
+
+    bool m_search_mode = false;
 };
 
 class HeaderBarToolButton : public QToolButton

--- a/src/control/header-bar.h
+++ b/src/control/header-bar.h
@@ -57,6 +57,7 @@ private Q_SLOTS:
     void updateMaximizeState();
     void startEdit();
     void finishEdit();
+    void searchButtonClicked();
 
 private:
     const QString m_uri;
@@ -71,6 +72,7 @@ private:
     QPushButton *m_go_back;
     QPushButton *m_go_forward;
     QToolButton *m_maximize_restore_button;
+    QToolButton *m_search_button;
 };
 
 class HeaderBarToolButton : public QToolButton

--- a/src/control/navigation-side-bar.cpp
+++ b/src/control/navigation-side-bar.cpp
@@ -29,19 +29,28 @@
 #include "side-bar-abstract-item.h"
 
 #include <QHeaderView>
+#include <QPushButton>
+
+#include <QEvent>
 
 #include <QDebug>
 
 NavigationSideBar::NavigationSideBar(QWidget *parent) : QTreeView(parent)
 {
+    installEventFilter(this);
+
     setAttribute(Qt::WA_TranslucentBackground);
     viewport()->setAttribute(Qt::WA_TranslucentBackground);
     header()->setSectionResizeMode(QHeaderView::ResizeToContents);
     header()->hide();
 
+    setHorizontalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
+
     m_model = new Peony::SideBarModel(this);
     m_proxy_model = new Peony::SideBarProxyFilterSortModel(this);
     m_proxy_model->setSourceModel(m_model);
+
+    this->setViewportMargins(4, 0, 4, 37);
 
     this->setModel(m_proxy_model);
 
@@ -95,4 +104,24 @@ NavigationSideBar::NavigationSideBar(QWidget *parent) : QTreeView(parent)
     });
 
     expandAll();
+
+    m_label_button = new QPushButton(QIcon::fromTheme("emblem-important-symbolic"), tr("All tags..."), this);
+    m_label_button->setCheckable(true);
+
+    connect(m_label_button, &QPushButton::clicked, this, &NavigationSideBar::labelButtonClicked);
+}
+
+bool NavigationSideBar::eventFilter(QObject *obj, QEvent *e)
+{
+    if (e->type() == QEvent::Resize) {
+        m_label_button->resize(this->width() - 8, 33);
+        m_label_button->move(4, this->height() - 37);
+    }
+    return false;
+}
+
+void NavigationSideBar::updateGeometries()
+{
+    setViewportMargins(0, 0, 0, 40);
+    QTreeView::updateGeometries();
 }

--- a/src/control/navigation-side-bar.cpp
+++ b/src/control/navigation-side-bar.cpp
@@ -1,0 +1,67 @@
+/*
+ * Peony-Qt
+ *
+ * Copyright (C) 2020, Tianjin KYLIN Information Technology Co., Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Authors: Yue Lan <lanyue@kylinos.cn>
+ *
+ */
+
+#include "navigation-side-bar.h"
+#include "side-bar-model.h"
+#include "side-bar-proxy-filter-sort-model.h"
+#include "side-bar-abstract-item.h"
+#include <QHeaderView>
+
+SideBar::SideBar(QWidget *parent) : QTreeView(parent)
+{
+    setAttribute(Qt::WA_TranslucentBackground);
+    viewport()->setAttribute(Qt::WA_TranslucentBackground);
+    header()->setSectionResizeMode(QHeaderView::ResizeToContents);
+    header()->hide();
+
+    m_model = new Peony::SideBarModel(this);
+    m_proxy_model = new Peony::SideBarProxyFilterSortModel(this);
+    m_proxy_model->setSourceModel(m_model);
+
+    this->setModel(m_proxy_model);
+
+    connect(this, &QTreeView::expanded, this, [=](const QModelIndex &index){
+        auto item = m_proxy_model->itemFromIndex(index);
+        item->findChildrenAsync();
+    });
+
+    connect(this, &QTreeView::collapsed, this, [=](const QModelIndex &index){
+        auto item = m_proxy_model->itemFromIndex(index);
+        item->clearChildren();
+    });
+
+    connect(this, &QTreeView::clicked, this, [=](const QModelIndex &index){
+        if (index.column() == 0) {
+            auto uri = index.data(Qt::UserRole).toString();
+            if (!uri.isNull())
+                Q_EMIT this->updateLocationRequest(uri);
+        }
+        if (index.column() == 1) {
+            auto item = m_proxy_model->itemFromIndex(index);
+            if (item->isMounted()) {
+                item->unmount();
+            }
+        }
+    });
+
+    expandAll();
+}

--- a/src/control/navigation-side-bar.cpp
+++ b/src/control/navigation-side-bar.cpp
@@ -32,7 +32,7 @@
 
 #include <QDebug>
 
-SideBar::SideBar(QWidget *parent) : QTreeView(parent)
+NavigationSideBar::NavigationSideBar(QWidget *parent) : QTreeView(parent)
 {
     setAttribute(Qt::WA_TranslucentBackground);
     viewport()->setAttribute(Qt::WA_TranslucentBackground);

--- a/src/control/navigation-side-bar.cpp
+++ b/src/control/navigation-side-bar.cpp
@@ -50,8 +50,6 @@ NavigationSideBar::NavigationSideBar(QWidget *parent) : QTreeView(parent)
     m_proxy_model = new Peony::SideBarProxyFilterSortModel(this);
     m_proxy_model->setSourceModel(m_model);
 
-    this->setViewportMargins(4, 0, 4, 37);
-
     this->setModel(m_proxy_model);
 
     connect(this, &QTreeView::expanded, [=](const QModelIndex &index){
@@ -122,6 +120,6 @@ bool NavigationSideBar::eventFilter(QObject *obj, QEvent *e)
 
 void NavigationSideBar::updateGeometries()
 {
-    setViewportMargins(0, 0, 0, 40);
+    setViewportMargins(4, 0, 4, 37);
     QTreeView::updateGeometries();
 }

--- a/src/control/navigation-side-bar.cpp
+++ b/src/control/navigation-side-bar.cpp
@@ -24,7 +24,13 @@
 #include "side-bar-model.h"
 #include "side-bar-proxy-filter-sort-model.h"
 #include "side-bar-abstract-item.h"
+
+#include "side-bar-menu.h"
+#include "side-bar-abstract-item.h"
+
 #include <QHeaderView>
+
+#include <QDebug>
 
 SideBar::SideBar(QWidget *parent) : QTreeView(parent)
 {
@@ -39,26 +45,51 @@ SideBar::SideBar(QWidget *parent) : QTreeView(parent)
 
     this->setModel(m_proxy_model);
 
-    connect(this, &QTreeView::expanded, this, [=](const QModelIndex &index){
+    connect(this, &QTreeView::expanded, [=](const QModelIndex &index){
         auto item = m_proxy_model->itemFromIndex(index);
+        qDebug()<<item->uri();
+        /*!
+          \bug can not expanded? enumerator can not get prepared signal, why?
+          */
         item->findChildrenAsync();
     });
 
-    connect(this, &QTreeView::collapsed, this, [=](const QModelIndex &index){
+    connect(this, &QTreeView::collapsed, [=](const QModelIndex &index){
         auto item = m_proxy_model->itemFromIndex(index);
         item->clearChildren();
     });
 
-    connect(this, &QTreeView::clicked, this, [=](const QModelIndex &index){
-        if (index.column() == 0) {
-            auto uri = index.data(Qt::UserRole).toString();
-            if (!uri.isNull())
-                Q_EMIT this->updateLocationRequest(uri);
+    connect(this, &QTreeView::clicked, [=](const QModelIndex &index){
+        switch (index.column()) {
+        case 0: {
+            auto item = m_proxy_model->itemFromIndex(index);
+            //some side bar item doesn't have a uri.
+            //do not emit signal with a null uri to window.
+            if (!item->uri().isNull())
+                Q_EMIT this->updateWindowLocationRequest(item->uri());
+            break;
         }
-        if (index.column() == 1) {
+        case 1: {
             auto item = m_proxy_model->itemFromIndex(index);
             if (item->isMounted()) {
+                auto leftIndex = m_proxy_model->index(index.row(), 0, index.parent());
+                this->collapse(leftIndex);
                 item->unmount();
+            }
+            break;
+        }
+        default:
+            break;
+        }
+    });
+
+    connect(this, &QTreeView::customContextMenuRequested, this, [=](const QPoint &pos){
+        auto index = indexAt(pos);
+        auto item = m_proxy_model->itemFromIndex(index);
+        if (item) {
+            if (item->type() != Peony::SideBarAbstractItem::SeparatorItem) {
+                Peony::SideBarMenu menu(item, nullptr);
+                menu.exec(QCursor::pos());
             }
         }
     });

--- a/src/control/navigation-side-bar.cpp
+++ b/src/control/navigation-side-bar.cpp
@@ -44,6 +44,10 @@ NavigationSideBar::NavigationSideBar(QWidget *parent) : QTreeView(parent)
     header()->setSectionResizeMode(QHeaderView::ResizeToContents);
     header()->hide();
 
+    setContextMenuPolicy(Qt::CustomContextMenu);
+
+    setExpandsOnDoubleClick(false);
+
     setHorizontalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
 
     m_model = new Peony::SideBarModel(this);

--- a/src/control/navigation-side-bar.cpp
+++ b/src/control/navigation-side-bar.cpp
@@ -37,6 +37,9 @@
 
 NavigationSideBar::NavigationSideBar(QWidget *parent) : QTreeView(parent)
 {
+    auto delegate = new NavigationSideBarItemDelegate(this);
+    setItemDelegate(delegate);
+
     installEventFilter(this);
 
     setAttribute(Qt::WA_TranslucentBackground);
@@ -126,4 +129,16 @@ void NavigationSideBar::updateGeometries()
 {
     setViewportMargins(4, 0, 4, 37);
     QTreeView::updateGeometries();
+}
+
+NavigationSideBarItemDelegate::NavigationSideBarItemDelegate(QObject *parent)
+{
+
+}
+
+QSize NavigationSideBarItemDelegate::sizeHint(const QStyleOptionViewItem &option, const QModelIndex &index) const
+{
+    auto size = QStyledItemDelegate::sizeHint(option, index);
+    size.setHeight(36);
+    return size;
 }

--- a/src/control/navigation-side-bar.h
+++ b/src/control/navigation-side-bar.h
@@ -37,7 +37,7 @@ public:
     explicit SideBar(QWidget *parent = nullptr);
 
 Q_SIGNALS:
-    void updateLocationRequest(const QString &uri);
+    void updateWindowLocationRequest(const QString &uri);
 
 private:
     Peony::SideBarProxyFilterSortModel *m_proxy_model;

--- a/src/control/navigation-side-bar.h
+++ b/src/control/navigation-side-bar.h
@@ -20,47 +20,28 @@
  *
  */
 
-#ifndef HEADERBAR_H
-#define HEADERBAR_H
+#ifndef SIDEBAR_H
+#define SIDEBAR_H
 
-#include <QToolBar>
-#include <QToolButton>
-#include <QPushButton>
+#include <QTreeView>
 
-class MainWindow;
+namespace Peony {
+class SideBarModel;
+class SideBarProxyFilterSortModel;
+}
 
-class HeaderBar : public QToolBar
+class SideBar : public QTreeView
 {
-    friend class MainWindow;
     Q_OBJECT
-private:
-    explicit HeaderBar(MainWindow *parent = nullptr);
+public:
+    explicit SideBar(QWidget *parent = nullptr);
 
 Q_SIGNALS:
     void updateLocationRequest(const QString &uri);
 
-private Q_SLOTS:
-    void setLocation(const QString &uri);
-
 private:
-    const QString m_uri;
-    MainWindow *m_window;
+    Peony::SideBarProxyFilterSortModel *m_proxy_model;
+    Peony::SideBarModel *m_model;
 };
 
-class HeaderBarToolButton : public QToolButton
-{
-    friend class HeaderBar;
-    friend class MainWindow;
-    Q_OBJECT;
-    explicit HeaderBarToolButton(QWidget *parent = nullptr);
-};
-
-class HeadBarPushButton : public QPushButton
-{
-    friend class HeaderBar;
-    friend class MainWindow;
-    Q_OBJECT
-    explicit HeadBarPushButton(QWidget *parent = nullptr);
-};
-
-#endif // HEADERBAR_H
+#endif // SIDEBAR_H

--- a/src/control/navigation-side-bar.h
+++ b/src/control/navigation-side-bar.h
@@ -20,8 +20,8 @@
  *
  */
 
-#ifndef SIDEBAR_H
-#define SIDEBAR_H
+#ifndef NAVIGATIONSIDEBAR_H
+#define NAVIGATIONSIDEBAR_H
 
 #include <QTreeView>
 
@@ -30,11 +30,11 @@ class SideBarModel;
 class SideBarProxyFilterSortModel;
 }
 
-class SideBar : public QTreeView
+class NavigationSideBar : public QTreeView
 {
     Q_OBJECT
 public:
-    explicit SideBar(QWidget *parent = nullptr);
+    explicit NavigationSideBar(QWidget *parent = nullptr);
 
 Q_SIGNALS:
     void updateWindowLocationRequest(const QString &uri);
@@ -44,4 +44,4 @@ private:
     Peony::SideBarModel *m_model;
 };
 
-#endif // SIDEBAR_H
+#endif // NAVIGATIONSIDEBAR_H

--- a/src/control/navigation-side-bar.h
+++ b/src/control/navigation-side-bar.h
@@ -24,6 +24,7 @@
 #define NAVIGATIONSIDEBAR_H
 
 #include <QTreeView>
+#include <QStyledItemDelegate>
 
 namespace Peony {
 class SideBarModel;
@@ -50,6 +51,14 @@ private:
     Peony::SideBarModel *m_model;
 
     QPushButton *m_label_button;
+};
+
+class NavigationSideBarItemDelegate : public QStyledItemDelegate
+{
+    friend class NavigationSideBar;
+    explicit NavigationSideBarItemDelegate(QObject *parent = nullptr);
+
+    QSize sizeHint(const QStyleOptionViewItem &option, const QModelIndex &index) const override;
 };
 
 #endif // NAVIGATIONSIDEBAR_H

--- a/src/control/navigation-side-bar.h
+++ b/src/control/navigation-side-bar.h
@@ -42,7 +42,7 @@ public:
     void updateGeometries();
 
 Q_SIGNALS:
-    void updateWindowLocationRequest(const QString &uri);
+    void updateWindowLocationRequest(const QString &uri, bool addHistory = true, bool force = false);
     void labelButtonClicked(bool checked);
 
 private:

--- a/src/control/navigation-tab-bar.cpp
+++ b/src/control/navigation-tab-bar.cpp
@@ -1,0 +1,84 @@
+#include "navigation-tab-bar.h"
+#include "x11-window-manager.h"
+
+#include "file-utils.h"
+
+#include <QToolButton>
+
+NavigationTabBar::NavigationTabBar(QWidget *parent) : QTabBar(parent)
+{
+    setFixedHeight(36);
+
+    setProperty("useStyleWindowManager", false);
+    setMovable(true);
+    setExpanding(false);
+    setTabsClosable(true);
+    X11WindowManager::getInstance()->registerWidget(this);
+
+    QToolButton *addPageButton = new QToolButton(this);
+    addPageButton->setFixedSize(QSize(36, 36));
+    addPageButton->setIcon(QIcon::fromTheme("list-add-symbolic"));
+    connect(addPageButton, &QToolButton::clicked, this, [=](){
+        addPage(nullptr, true);
+    });
+
+    m_float_button = addPageButton;
+
+    connect(this, &QTabBar::tabCloseRequested, this, [=](int index){
+        removeTab(index);
+    });
+
+    addPage("file:///");
+    addPage("file:///etc");
+
+    setDrawBase(false);
+}
+
+void NavigationTabBar::addPages(const QStringList &uri)
+{
+
+}
+
+void NavigationTabBar::addPage(const QString &uri, bool jumpToNewTab)
+{
+    if (!uri.isNull()) {
+        auto iconName = Peony::FileUtils::getFileIconName(uri);
+        auto displayName = Peony::FileUtils::getFileDisplayName(uri);
+        addTab(QIcon::fromTheme(iconName), displayName);
+        setTabData(count() - 1, uri);
+        if (jumpToNewTab)
+            setCurrentIndex(count() - 1);
+        Q_EMIT this->pageAdded(uri);
+    } else {
+        QString uri = tabData(count() - 1).toString();
+        addPage(uri, jumpToNewTab);
+    }
+}
+
+void NavigationTabBar::tabRemoved(int index)
+{
+    QTabBar::tabRemoved(index);
+    if (count() == 0) {
+        Q_EMIT closeWindowRequest();
+    }
+    relayoutFloatButton(false);
+}
+
+void NavigationTabBar::tabInserted(int index)
+{
+    QTabBar::tabInserted(index);
+    relayoutFloatButton(true);
+}
+
+void NavigationTabBar::relayoutFloatButton(bool insterted)
+{
+    if (count() == 0)
+        return;
+    qDebug()<<"relayout";
+    auto lastTabRect = tabRect(count() - 1);
+    if (insterted) {
+        m_float_button->move(lastTabRect.right(), 0);
+    } else {
+        m_float_button->move(lastTabRect.right(), 0);
+    }
+}

--- a/src/control/navigation-tab-bar.cpp
+++ b/src/control/navigation-tab-bar.cpp
@@ -1,3 +1,25 @@
+/*
+ * Peony-Qt
+ *
+ * Copyright (C) 2020, Tianjin KYLIN Information Technology Co., Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Authors: Yue Lan <lanyue@kylinos.cn>
+ *
+ */
+
 #include "navigation-tab-bar.h"
 #include "x11-window-manager.h"
 
@@ -5,8 +27,13 @@
 
 #include <QToolButton>
 
+static TabBarStyle *global_instance = nullptr;
+
 NavigationTabBar::NavigationTabBar(QWidget *parent) : QTabBar(parent)
 {
+    setStyle(TabBarStyle::getStyle());
+
+    setContentsMargins(0, 0, 0, 0);
     setFixedHeight(36);
 
     setProperty("useStyleWindowManager", false);
@@ -102,5 +129,26 @@ void NavigationTabBar::relayoutFloatButton(bool insterted)
         m_float_button->move(lastTabRect.right(), 0);
     } else {
         m_float_button->move(lastTabRect.right(), 0);
+    }
+}
+
+TabBarStyle *TabBarStyle::getStyle()
+{
+    if (!global_instance) {
+        global_instance = new TabBarStyle;
+    }
+    return global_instance;
+}
+
+int TabBarStyle::pixelMetric(QStyle::PixelMetric metric, const QStyleOption *option, const QWidget *widget) const
+{
+    switch (metric) {
+    case PM_TabBarTabShiftVertical:
+    case PM_TabBarBaseHeight:
+        return 0;
+    case PM_TabBarBaseOverlap:
+        return 0;
+    default:
+        return QProxyStyle::pixelMetric(metric, option, widget);
     }
 }

--- a/src/control/navigation-tab-bar.cpp
+++ b/src/control/navigation-tab-bar.cpp
@@ -80,6 +80,16 @@ void NavigationTabBar::addPages(const QStringList &uri)
 
 }
 
+void NavigationTabBar::updateLocation(int index, const QString &uri)
+{
+    auto iconName = Peony::FileUtils::getFileIconName(uri);
+    auto displayName = Peony::FileUtils::getFileDisplayName(uri);
+    setTabText(index, displayName);
+    setTabIcon(index, QIcon::fromTheme(iconName));
+    setTabData(index, uri);
+    relayoutFloatButton(false);
+}
+
 void NavigationTabBar::addPage(const QString &uri, bool jumpToNewTab)
 {
     if (!uri.isNull()) {

--- a/src/control/navigation-tab-bar.cpp
+++ b/src/control/navigation-tab-bar.cpp
@@ -34,7 +34,7 @@ NavigationTabBar::NavigationTabBar(QWidget *parent) : QTabBar(parent)
     setStyle(TabBarStyle::getStyle());
 
     setContentsMargins(0, 0, 0, 0);
-    setFixedHeight(36);
+    //setFixedHeight(36);
 
     setProperty("useStyleWindowManager", false);
     setMovable(true);
@@ -59,7 +59,7 @@ NavigationTabBar::NavigationTabBar(QWidget *parent) : QTabBar(parent)
     });
 
     QToolButton *addPageButton = new QToolButton(this);
-    addPageButton->setFixedSize(QSize(36, 36));
+    addPageButton->setFixedSize(QSize(this->height() + 2, this->height() + 2));
     addPageButton->setIcon(QIcon::fromTheme("list-add-symbolic"));
     connect(addPageButton, &QToolButton::clicked, this, [=](){
         auto uri = tabData(currentIndex()).toString();

--- a/src/control/navigation-tab-bar.h
+++ b/src/control/navigation-tab-bar.h
@@ -1,7 +1,30 @@
+/*
+ * Peony-Qt
+ *
+ * Copyright (C) 2020, Tianjin KYLIN Information Technology Co., Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Authors: Yue Lan <lanyue@kylinos.cn>
+ *
+ */
+
 #ifndef NAVIGATIONTABBAR_H
 #define NAVIGATIONTABBAR_H
 
 #include <QTabBar>
+#include <QProxyStyle>
 
 class QToolButton;
 
@@ -27,6 +50,16 @@ protected:
 
 private:
     QToolButton *m_float_button;
+};
+
+class TabBarStyle : public QProxyStyle
+{
+    friend class NavigationTabBar;
+    friend class TabWidget;
+    static TabBarStyle *getStyle();
+    TabBarStyle() {}
+
+    int pixelMetric(PixelMetric metric, const QStyleOption *option = nullptr, const QWidget *widget = nullptr) const override;
 };
 
 #endif // NAVIGATIONTABBAR_H

--- a/src/control/navigation-tab-bar.h
+++ b/src/control/navigation-tab-bar.h
@@ -1,0 +1,31 @@
+#ifndef NAVIGATIONTABBAR_H
+#define NAVIGATIONTABBAR_H
+
+#include <QTabBar>
+
+class QToolButton;
+
+class NavigationTabBar : public QTabBar
+{
+    Q_OBJECT
+public:
+    explicit NavigationTabBar(QWidget *parent = nullptr);
+
+Q_SIGNALS:
+    void pageAdded(const QString &uri);
+    void closeWindowRequest();
+
+public Q_SLOTS:
+    void addPage(const QString &uri = nullptr, bool jumpToNewTab = false);
+    void addPages(const QStringList &uri);
+
+protected:
+    void tabRemoved(int index) override;
+    void tabInserted(int index) override;
+    void relayoutFloatButton(bool insterted);
+
+private:
+    QToolButton *m_float_button;
+};
+
+#endif // NAVIGATIONTABBAR_H

--- a/src/control/navigation-tab-bar.h
+++ b/src/control/navigation-tab-bar.h
@@ -14,6 +14,7 @@ public:
 Q_SIGNALS:
     void pageAdded(const QString &uri);
     void closeWindowRequest();
+    void addPageRequest(const QString &uri, bool jumpTo);
 
 public Q_SLOTS:
     void addPage(const QString &uri = nullptr, bool jumpToNewTab = false);

--- a/src/control/navigation-tab-bar.h
+++ b/src/control/navigation-tab-bar.h
@@ -42,6 +42,7 @@ Q_SIGNALS:
 public Q_SLOTS:
     void addPage(const QString &uri = nullptr, bool jumpToNewTab = false);
     void addPages(const QStringList &uri);
+    void updateLocation(int index, const QString &uri);
 
 protected:
     void tabRemoved(int index) override;

--- a/src/control/operation-menu.cpp
+++ b/src/control/operation-menu.cpp
@@ -27,6 +27,8 @@
 #include <QToolButton>
 #include <QWidgetAction>
 
+#include "global-settings.h"
+
 OperationMenu::OperationMenu(MainWindow *window, QWidget *parent) : QMenu(parent)
 {
     m_window = window;
@@ -46,20 +48,46 @@ OperationMenu::OperationMenu(MainWindow *window, QWidget *parent) : QMenu(parent
 
     addSeparator();
 
-    addAction(tr("Show Hidden"));
-    addAction(tr("Forbid thumbnailing"));
-    addAction(tr("Resident in Backend"));
+    auto showHidden = addAction(tr("Show Hidden"), this, [=](bool checked){
+        //window set show hidden
+    });
+    m_show_hidden = showHidden;
+    showHidden->setCheckable(true);
+
+    auto forbidThumbnailing = addAction(tr("Forbid thumbnailing"), this, [=](bool checked){
+        //FIXME:
+    });
+    m_forbid_thumbnailing = forbidThumbnailing;
+    forbidThumbnailing->setCheckable(true);
+
+    auto residentInBackend = addAction(tr("Resident in Backend"), this, [=](bool checked){
+        //FIXME:
+    });
+    m_resident_in_backend = residentInBackend;
+    residentInBackend->setCheckable(true);
 
     addSeparator();
 
-    addAction(tr("Help"));
+    addAction(QIcon::fromTheme("help-app-symbolic"), tr("Help"));
 
-    addAction(tr("About"));
+    addAction(QIcon::fromTheme("help-about", QIcon::fromTheme("gtk-about-symbolic")), tr("About"));
 }
 
 void OperationMenu::updateMenu()
 {
+    m_show_hidden->setChecked(Peony::GlobalSettings::getInstance()->isExist("show-hidden")?
+                                  Peony::GlobalSettings::getInstance()->getValue("show-hidden").toBool():
+                                  false);
 
+    m_forbid_thumbnailing->setChecked(Peony::GlobalSettings::getInstance()->isExist("do-not-thumbnail")?
+                                          Peony::GlobalSettings::getInstance()->getValue("do-not-thumbnail").toBool():
+                                          false);
+
+    m_resident_in_backend->setChecked(Peony::GlobalSettings::getInstance()->isExist("resident")?
+                                          Peony::GlobalSettings::getInstance()->getValue("resident").toBool():
+                                          false);
+
+    //get window current directory and selections, then update ohter actions.
 }
 
 OperationMenuEditWidget::OperationMenuEditWidget(QWidget *parent) : QWidget(parent)
@@ -102,4 +130,9 @@ OperationMenuEditWidget::OperationMenuEditWidget(QWidget *parent) : QWidget(pare
     hbox->addWidget(trash);
 
     vbox->addLayout(hbox);
+}
+
+void OperationMenuEditWidget::updateActions(const QString &currentDirUri, const QStringList &selections)
+{
+    //FIXME:
 }

--- a/src/control/operation-menu.cpp
+++ b/src/control/operation-menu.cpp
@@ -45,7 +45,11 @@ OperationMenu::OperationMenu(MainWindow *window, QWidget *parent) : QMenu(parent
 
     addSeparator();
 
-    addAction(tr("Conditional Filter"));
+    //addAction(tr("Conditional Filter"));
+    auto advanceSearch = addAction(tr("Advance Search"), this, [=]()
+    {
+       m_window->advanceSearch();
+    });
 
     addSeparator();
 
@@ -57,6 +61,7 @@ OperationMenu::OperationMenu(MainWindow *window, QWidget *parent) : QMenu(parent
 
     auto showHidden = addAction(tr("Show Hidden"), this, [=](bool checked){
         //window set show hidden
+        m_window->setShowHidden(checked);
     });
     m_show_hidden = showHidden;
     showHidden->setCheckable(true);

--- a/src/control/operation-menu.cpp
+++ b/src/control/operation-menu.cpp
@@ -20,6 +20,7 @@
  *
  */
 
+#include "main-window.h"
 #include "operation-menu.h"
 #include <QHBoxLayout>
 #include <QVBoxLayout>
@@ -47,6 +48,12 @@ OperationMenu::OperationMenu(MainWindow *window, QWidget *parent) : QMenu(parent
     addAction(tr("Conditional Filter"));
 
     addSeparator();
+
+    auto keepAllow = addAction(tr("Keep Allow"), this, [=](bool checked){
+        m_window->setWindowFlag(Qt::WindowStaysOnTopHint, checked);
+        m_window->show();
+    });
+    keepAllow->setCheckable(true);
 
     auto showHidden = addAction(tr("Show Hidden"), this, [=](bool checked){
         //window set show hidden

--- a/src/control/operation-menu.cpp
+++ b/src/control/operation-menu.cpp
@@ -1,13 +1,105 @@
+/*
+ * Peony-Qt
+ *
+ * Copyright (C) 2020, Tianjin KYLIN Information Technology Co., Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Authors: Yue Lan <lanyue@kylinos.cn>
+ *
+ */
+
 #include "operation-menu.h"
+#include <QHBoxLayout>
+#include <QVBoxLayout>
+#include <QLabel>
+#include <QToolButton>
+#include <QWidgetAction>
 
 OperationMenu::OperationMenu(MainWindow *window, QWidget *parent) : QMenu(parent)
 {
     m_window = window;
 
     connect(this, &QMenu::aboutToShow, this, &OperationMenu::updateMenu);
+
+    //FIXME: implement all actions.
+
+    auto editWidgetContainer = new QWidgetAction(this);
+    auto editWidget = new OperationMenuEditWidget(this);
+    editWidgetContainer->setDefaultWidget(editWidget);
+    addAction(editWidgetContainer);
+
+    addSeparator();
+
+    addAction(tr("Conditional Filter"));
+
+    addSeparator();
+
+    addAction(tr("Show Hidden"));
+    addAction(tr("Forbid thumbnailing"));
+    addAction(tr("Resident in Backend"));
+
+    addSeparator();
+
+    addAction(tr("Help"));
+
+    addAction(tr("About"));
 }
 
 void OperationMenu::updateMenu()
 {
 
+}
+
+OperationMenuEditWidget::OperationMenuEditWidget(QWidget *parent) : QWidget(parent)
+{
+    auto vbox = new QVBoxLayout;
+    setLayout(vbox);
+
+    auto title = new QLabel(this);
+    title->setText(tr("Edit"));
+    title->setAlignment(Qt::AlignCenter);
+    vbox->addWidget(title);
+
+    auto hbox = new QHBoxLayout;
+    auto copy = new QToolButton(this);
+    copy->setFixedSize(QSize(40, 40));
+    copy->setIcon(QIcon::fromTheme("edit-copy-symbolic"));
+    copy->setIconSize(QSize(16, 16));
+    copy->setAutoRaise(false);
+    hbox->addWidget(copy);
+
+    auto paste = new QToolButton(this);
+    paste->setFixedSize(QSize(40, 40));
+    paste->setIcon(QIcon::fromTheme("edit-paste-symbolic"));
+    paste->setIconSize(QSize(16, 16));
+    paste->setAutoRaise(false);
+    hbox->addWidget(paste);
+
+    auto cut = new QToolButton(this);
+    cut->setFixedSize(QSize(40, 40));
+    cut->setIcon(QIcon::fromTheme("edit-cut-symbolic"));
+    cut->setIconSize(QSize(16, 16));
+    cut->setAutoRaise(false);
+    hbox->addWidget(cut);
+
+    auto trash = new QToolButton(this);
+    trash->setFixedSize(QSize(40, 40));
+    trash->setIcon(QIcon::fromTheme("user-trash-symbolic"));
+    trash->setIconSize(QSize(16, 16));
+    trash->setAutoRaise(false);
+    hbox->addWidget(trash);
+
+    vbox->addLayout(hbox);
 }

--- a/src/control/operation-menu.cpp
+++ b/src/control/operation-menu.cpp
@@ -1,0 +1,13 @@
+#include "operation-menu.h"
+
+OperationMenu::OperationMenu(MainWindow *window, QWidget *parent) : QMenu(parent)
+{
+    m_window = window;
+
+    connect(this, &QMenu::aboutToShow, this, &OperationMenu::updateMenu);
+}
+
+void OperationMenu::updateMenu()
+{
+
+}

--- a/src/control/operation-menu.h
+++ b/src/control/operation-menu.h
@@ -1,0 +1,21 @@
+#ifndef OPERATIONMENU_H
+#define OPERATIONMENU_H
+
+#include <QMenu>
+
+class MainWindow;
+
+class OperationMenu : public QMenu
+{
+    Q_OBJECT
+public:
+    explicit OperationMenu(MainWindow *window, QWidget *parent = nullptr);
+
+public Q_SLOTS:
+    void updateMenu();
+
+private:
+    MainWindow *m_window;
+};
+
+#endif // OPERATIONMENU_H

--- a/src/control/operation-menu.h
+++ b/src/control/operation-menu.h
@@ -1,3 +1,25 @@
+/*
+ * Peony-Qt
+ *
+ * Copyright (C) 2020, Tianjin KYLIN Information Technology Co., Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Authors: Yue Lan <lanyue@kylinos.cn>
+ *
+ */
+
 #ifndef OPERATIONMENU_H
 #define OPERATIONMENU_H
 
@@ -16,6 +38,13 @@ public Q_SLOTS:
 
 private:
     MainWindow *m_window;
+};
+
+class OperationMenuEditWidget : public QWidget
+{
+    friend class OperationMenu;
+    Q_OBJECT
+    explicit OperationMenuEditWidget(QWidget *parent = nullptr);
 };
 
 #endif // OPERATIONMENU_H

--- a/src/control/operation-menu.h
+++ b/src/control/operation-menu.h
@@ -37,6 +37,11 @@ public Q_SLOTS:
     void updateMenu();
 
 private:
+    QAction *m_show_hidden;
+    QAction *m_forbid_thumbnailing;
+    QAction *m_resident_in_backend;
+
+private:
     MainWindow *m_window;
 };
 
@@ -45,6 +50,13 @@ class OperationMenuEditWidget : public QWidget
     friend class OperationMenu;
     Q_OBJECT
     explicit OperationMenuEditWidget(QWidget *parent = nullptr);
+
+    void updateActions(const QString &currentDirUri, const QStringList &selections);
+
+    QAction *m_copy;
+    QAction *m_paste;
+    QAction *m_cut;
+    QAction *m_trash;
 };
 
 #endif // OPERATIONMENU_H

--- a/src/control/operation-menu.h
+++ b/src/control/operation-menu.h
@@ -26,6 +26,8 @@
 #include <QMenu>
 
 class MainWindow;
+class QToolButton;
+class OperationMenuEditWidget;
 
 class OperationMenu : public QMenu
 {
@@ -43,20 +45,27 @@ private:
 
 private:
     MainWindow *m_window;
+    OperationMenuEditWidget *m_edit_widget;
 };
 
 class OperationMenuEditWidget : public QWidget
 {
+public:
     friend class OperationMenu;
     Q_OBJECT
-    explicit OperationMenuEditWidget(QWidget *parent = nullptr);
+
+Q_SIGNALS:
+    void operationAccepted();
+
+private:
+    explicit OperationMenuEditWidget(MainWindow *window, QWidget *parent = nullptr);
 
     void updateActions(const QString &currentDirUri, const QStringList &selections);
 
-    QAction *m_copy;
-    QAction *m_paste;
-    QAction *m_cut;
-    QAction *m_trash;
+    QToolButton *m_copy;
+    QToolButton *m_paste;
+    QToolButton *m_cut;
+    QToolButton *m_trash;
 };
 
 #endif // OPERATIONMENU_H

--- a/src/control/sort-type-menu.cpp
+++ b/src/control/sort-type-menu.cpp
@@ -22,6 +22,8 @@
 
 #include "sort-type-menu.h"
 
+#include <QDebug>
+
 SortTypeMenu::SortTypeMenu(QWidget *parent) : QMenu(parent)
 {
     auto sortTypeGroup = new QActionGroup(this);
@@ -44,10 +46,6 @@ SortTypeMenu::SortTypeMenu(QWidget *parent) : QMenu(parent)
     modifiedDate->setCheckable(true);
     sortTypeGroup->addAction(modifiedDate);
 
-    auto fileLabel = addAction(tr("File Label"));
-    fileLabel->setCheckable(true);
-    sortTypeGroup->addAction(fileLabel);
-
     connect(sortTypeGroup, &QActionGroup::triggered, this, [=](QAction *action){
         int index = sortTypeGroup->actions().indexOf(action);
         switchSortTypeRequest(index);
@@ -67,24 +65,28 @@ SortTypeMenu::SortTypeMenu(QWidget *parent) : QMenu(parent)
     descending->setCheckable(true);
     sortOrderGroup->addAction(descending);
 
-    connect(sortTypeGroup, &QActionGroup::triggered, this, [=](QAction *action){
-        int index = sortTypeGroup->actions().indexOf(action);
+    connect(sortOrderGroup, &QActionGroup::triggered, this, [=](QAction *action){
+        int index = sortOrderGroup->actions().indexOf(action);
         switchSortOrderRequest(Qt::SortOrder(index));
     });
 }
 
 void SortTypeMenu::setSortType(int type)
 {
+    m_sort_types->actions().at(type)->setChecked(true);
+    qDebug()<<m_sort_type<<type;
     if (m_sort_type != type) {
         m_sort_type = type;
-        m_sort_types->triggered(m_sort_types->actions().at(type));
     }
 }
 
 void SortTypeMenu::setSortOrder(Qt::SortOrder order)
 {
+    qDebug()<<m_sort_order<<order;
+    if (order < 0)
+        return;
+    m_sort_orders->actions().at(order)->setChecked(true);
     if (m_sort_order != order) {
         m_sort_order = order;
-        m_sort_orders->triggered(m_sort_orders->actions().at(order));
     }
 }

--- a/src/control/sort-type-menu.cpp
+++ b/src/control/sort-type-menu.cpp
@@ -1,0 +1,90 @@
+/*
+ * Peony-Qt
+ *
+ * Copyright (C) 2020, Tianjin KYLIN Information Technology Co., Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Authors: Yue Lan <lanyue@kylinos.cn>
+ *
+ */
+
+#include "sort-type-menu.h"
+
+SortTypeMenu::SortTypeMenu(QWidget *parent) : QMenu(parent)
+{
+    auto sortTypeGroup = new QActionGroup(this);
+    m_sort_types = sortTypeGroup;
+    sortTypeGroup->setExclusive(true);
+
+    auto fileName = addAction(tr("File Name"));
+    fileName->setCheckable(true);
+    sortTypeGroup->addAction(fileName);
+
+    auto fileSize = addAction(tr("File Size"));
+    fileSize->setCheckable(true);
+    sortTypeGroup->addAction(fileSize);
+
+    auto fileType = addAction(tr("File Type"));
+    fileType->setCheckable(true);
+    sortTypeGroup->addAction(fileType);
+
+    auto modifiedDate = addAction(tr("Modified Data"));
+    modifiedDate->setCheckable(true);
+    sortTypeGroup->addAction(modifiedDate);
+
+    auto fileLabel = addAction(tr("File Label"));
+    fileLabel->setCheckable(true);
+    sortTypeGroup->addAction(fileLabel);
+
+    connect(sortTypeGroup, &QActionGroup::triggered, this, [=](QAction *action){
+        int index = sortTypeGroup->actions().indexOf(action);
+        switchSortTypeRequest(index);
+    });
+
+    addSeparator();
+
+    auto sortOrderGroup = new QActionGroup(this);
+    m_sort_orders = sortOrderGroup;
+    sortOrderGroup->setExclusive(true);
+
+    auto ascending = addAction(tr("Ascending"));
+    ascending->setCheckable(true);
+    sortOrderGroup->addAction(ascending);
+
+    auto descending = addAction(tr("Descending"));
+    descending->setCheckable(true);
+    sortOrderGroup->addAction(descending);
+
+    connect(sortTypeGroup, &QActionGroup::triggered, this, [=](QAction *action){
+        int index = sortTypeGroup->actions().indexOf(action);
+        switchSortOrderRequest(Qt::SortOrder(index));
+    });
+}
+
+void SortTypeMenu::setSortType(int type)
+{
+    if (m_sort_type != type) {
+        m_sort_type = type;
+        m_sort_types->triggered(m_sort_types->actions().at(type));
+    }
+}
+
+void SortTypeMenu::setSortOrder(Qt::SortOrder order)
+{
+    if (m_sort_order != order) {
+        m_sort_order = order;
+        m_sort_orders->triggered(m_sort_orders->actions().at(order));
+    }
+}

--- a/src/control/sort-type-menu.h
+++ b/src/control/sort-type-menu.h
@@ -1,0 +1,50 @@
+/*
+ * Peony-Qt
+ *
+ * Copyright (C) 2020, Tianjin KYLIN Information Technology Co., Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Authors: Yue Lan <lanyue@kylinos.cn>
+ *
+ */
+
+#ifndef SORTTYPEMENU_H
+#define SORTTYPEMENU_H
+
+#include <QMenu>
+
+class SortTypeMenu : public QMenu
+{
+    Q_OBJECT
+public:
+    explicit SortTypeMenu(QWidget *parent = nullptr);
+
+Q_SIGNALS:
+    void switchSortTypeRequest(int type);
+    void switchSortOrderRequest(Qt::SortOrder order);
+
+public Q_SLOTS:
+    void setSortType(int type);
+    void setSortOrder(Qt::SortOrder order);
+
+private:
+    int m_sort_type;
+    Qt::SortOrder m_sort_order;
+
+    QActionGroup *m_sort_types;
+    QActionGroup *m_sort_orders;
+};
+
+#endif // SORTTYPEMENU_H

--- a/src/control/sort-type-menu.h
+++ b/src/control/sort-type-menu.h
@@ -40,8 +40,8 @@ public Q_SLOTS:
     void setSortOrder(Qt::SortOrder order);
 
 private:
-    int m_sort_type;
-    Qt::SortOrder m_sort_order;
+    int m_sort_type = 0;
+    Qt::SortOrder m_sort_order = Qt::AscendingOrder;
 
     QActionGroup *m_sort_types;
     QActionGroup *m_sort_orders;

--- a/src/control/tab-widget.cpp
+++ b/src/control/tab-widget.cpp
@@ -16,8 +16,12 @@
 
 #include "directory-view-container.h"
 
+#include "peony-main-window-style.h"
+
 TabWidget::TabWidget(QWidget *parent) : QMainWindow(parent)
 {
+    setStyle(PeonyMainWindowStyle::getStyle());
+
     setAttribute(Qt::WA_TranslucentBackground);
 
     m_tab_bar = new NavigationTabBar(this);
@@ -73,10 +77,7 @@ TabWidget::TabWidget(QWidget *parent) : QMainWindow(parent)
     addDockWidget(Qt::RightDockWidgetArea, m_preview_page_container);
     m_preview_page_container->hide();
 
-    auto c = new QDockWidget(this);
-    c->setTitleBarWidget(new QWidget(this));
-    c->setWidget(m_stack);
-    addDockWidget(Qt::LeftDockWidgetArea, c);
+    setCentralWidget(m_stack);
 }
 
 void TabWidget::setCurrentIndex(int index)

--- a/src/control/tab-widget.cpp
+++ b/src/control/tab-widget.cpp
@@ -1,0 +1,143 @@
+#include "tab-widget.h"
+//#include "navigation-tab-bar.h"
+
+#include "preview-page-factory-manager.h"
+#include "preview-page-plugin-iface.h"
+
+#include <QStackedWidget>
+#include <QToolButton>
+#include <QHBoxLayout>
+#include <QDockWidget>
+#include <QToolBar>
+
+#include <QAction>
+
+#include <QTimer>
+
+#include "directory-view-container.h"
+
+TabWidget::TabWidget(QWidget *parent) : QMainWindow(parent)
+{
+    setAttribute(Qt::WA_TranslucentBackground);
+
+    m_tab_bar = new NavigationTabBar(this);
+    m_tab_bar->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
+    m_stack = new QStackedWidget(this);
+    m_buttons = new PreviewPageButtonGroups(this);
+    m_preview_page_container = new QDockWidget(this);
+    m_preview_page_container->setTitleBarWidget(new QWidget);
+    m_preview_page_container->setFeatures(QDockWidget::NoDockWidgetFeatures);
+
+    connect(m_buttons, &PreviewPageButtonGroups::previewPageButtonTrigger, [=](bool trigger, const QString &id){
+        if (trigger) {
+            auto plugin = Peony::PreviewPageFactoryManager::getInstance()->getPlugin(id);
+            setPreviewPage(plugin->createPreviewPage());
+        } else {
+            setPreviewPage(nullptr);
+        }
+    });
+
+    connect(m_tab_bar, &QTabBar::currentChanged, this, &TabWidget::changeCurrentIndex);
+    connect(m_tab_bar, &QTabBar::tabMoved, this, &TabWidget::moveTab);
+    connect(m_tab_bar, &QTabBar::tabCloseRequested, this, &TabWidget::removeTab);
+    connect(m_tab_bar, &NavigationTabBar::addPageRequest, this, &TabWidget::addPage);
+
+    connect(m_tab_bar, &NavigationTabBar::closeWindowRequest, this, &TabWidget::closeWindowRequest);
+
+    QToolBar *t = new QToolBar(this);
+    t->setContextMenuPolicy(Qt::CustomContextMenu);
+    t->setContentsMargins(0, 0, 0, 0);
+    t->setMovable(false);
+    t->addWidget(m_tab_bar);
+    auto manager = Peony::PreviewPageFactoryManager::getInstance();
+    auto pluginNames = manager->getPluginNames();
+    for (auto name : pluginNames) {
+        auto plugin = manager->getPlugin(name);
+        auto action = t->addAction(plugin->icon(), plugin->name());
+        action->setCheckable(true);
+        auto button = qobject_cast<QToolButton *>(t->widgetForAction(action));
+        button->setIcon(plugin->icon());
+        button->setToolTip(plugin->name());
+        button->setWhatsThis(plugin->description());
+        button->setFixedSize(QSize(26, 26));
+        button->setIconSize(QSize(16, 16));
+        //m_buttons->addButton(button);
+
+        connect(action, &QAction::triggered, this, [=](bool checked){
+            Q_EMIT m_buttons->previewPageButtonTrigger(checked, plugin->name());
+        });
+    }
+
+    addToolBar(t);
+
+    addDockWidget(Qt::RightDockWidgetArea, m_preview_page_container);
+    m_preview_page_container->hide();
+
+    auto c = new QDockWidget(this);
+    c->setTitleBarWidget(new QWidget(this));
+    c->setWidget(m_stack);
+    addDockWidget(Qt::LeftDockWidgetArea, c);
+}
+
+void TabWidget::setCurrentIndex(int index)
+{
+    m_tab_bar->setCurrentIndex(index);
+    m_stack->setCurrentIndex(index);
+}
+
+void TabWidget::setPreviewPage(Peony::PreviewPageIface *previewPage)
+{
+    bool visible = false;
+    auto previewPageWidget = dynamic_cast<QWidget *>(previewPage);
+    if (previewPageWidget)
+        visible = true;
+
+    if (m_preview_page) {
+        m_preview_page_container->setWidget(nullptr);
+        m_preview_page->closePreviewPage();
+    }
+    m_preview_page = previewPage;
+    m_preview_page_container->setWidget(previewPageWidget);
+
+    m_preview_page_container->blockSignals(!visible);
+    m_preview_page_container->setVisible(visible);
+}
+
+void TabWidget::addPage(const QString &uri, bool jumpTo)
+{
+    m_tab_bar->addPage(uri, jumpTo);
+    auto viewContainer = new Peony::DirectoryViewContainer(m_stack);
+    m_stack->addWidget(viewContainer);
+    viewContainer->goToUri(uri, true, true);
+    if (jumpTo) {
+        m_stack->setCurrentWidget(viewContainer);
+    }
+}
+
+void TabWidget::changeCurrentIndex(int index)
+{
+    m_tab_bar->setCurrentIndex(index);
+    m_stack->setCurrentIndex(index);
+    Q_EMIT currentIndexChanged(index);
+}
+
+void TabWidget::moveTab(int from, int to)
+{
+    auto w = m_stack->widget(from);
+    if (!w)
+        return;
+    m_stack->removeWidget(w);
+    m_stack->insertWidget(to, w);
+    Q_EMIT tabMoved(from, to);
+}
+
+void TabWidget::removeTab(int index)
+{
+    m_tab_bar->removeTab(index);
+    m_stack->removeWidget(m_stack->widget(index));
+}
+
+PreviewPageButtonGroups::PreviewPageButtonGroups(QWidget *parent) : QButtonGroup(parent)
+{
+    setExclusive(true);
+}

--- a/src/control/tab-widget.cpp
+++ b/src/control/tab-widget.cpp
@@ -55,7 +55,7 @@ TabWidget::TabWidget(QWidget *parent) : QMainWindow(parent)
     setAttribute(Qt::WA_TranslucentBackground);
 
     m_tab_bar = new NavigationTabBar(this);
-    m_tab_bar->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
+    m_tab_bar->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Fixed);
     m_stack = new QStackedWidget(this);
     m_stack->setContentsMargins(0, 0, 0, 0);
     m_buttons = new PreviewPageButtonGroups(this);
@@ -109,6 +109,11 @@ TabWidget::TabWidget(QWidget *parent) : QMainWindow(parent)
         });
     }
     previewButtons->addActions(group->actions());
+    for (auto action : group->actions()) {
+        auto button = qobject_cast<QToolButton *>(previewButtons->widgetForAction(action));
+        button->setFixedSize(20, 20);
+        button->setIconSize(QSize(16, 16));
+    }
     t->addWidget(previewButtons);
 
     QWidget *w = new QWidget();

--- a/src/control/tab-widget.cpp
+++ b/src/control/tab-widget.cpp
@@ -213,9 +213,11 @@ void TabWidget::addPage(const QString &uri, bool jumpTo)
 {
     m_tab_bar->addPage(uri, jumpTo);
     auto viewContainer = new Peony::DirectoryViewContainer(m_stack);
+    viewContainer->setSortType(Peony::FileItemModel::FileName);
+    viewContainer->setSortOrder(Qt::AscendingOrder);
 
     m_stack->addWidget(viewContainer);
-    viewContainer->goToUri(uri, true, true);
+    viewContainer->goToUri(uri, false, true);
     if (jumpTo) {
         m_stack->setCurrentWidget(viewContainer);
     }
@@ -360,6 +362,7 @@ void TabWidget::removeTab(int index)
 
 void TabWidget::bindContainerSignal(Peony::DirectoryViewContainer *container)
 {
+    connect(container, &Peony::DirectoryViewContainer::updateWindowLocationRequest, this, &TabWidget::updateWindowLocationRequest);
     connect(container, &Peony::DirectoryViewContainer::directoryChanged, this, &TabWidget::activePageLocationChanged);
     connect(container, &Peony::DirectoryViewContainer::selectionChanged, this, &TabWidget::activePageSelectionChanged);
     connect(container, &Peony::DirectoryViewContainer::viewTypeChanged, this, &TabWidget::activePageViewTypeChanged);

--- a/src/control/tab-widget.cpp
+++ b/src/control/tab-widget.cpp
@@ -137,8 +137,10 @@ TabWidget::TabWidget(QWidget *parent) : QMainWindow(parent)
         updatePreviewPage();
     });
 
-    connect(this, &TabWidget::currentIndexChanged, this, [=](){
-        updatePreviewPage();
+    connect(this, &TabWidget::activePageChanged, this, [=](){
+        QTimer::singleShot(100, this, [=](){
+            this->updatePreviewPage();
+        });
     });
 }
 
@@ -217,8 +219,10 @@ void TabWidget::setPreviewPage(Peony::PreviewPageIface *previewPage)
 
     m_preview_page = previewPage;
 
-    if (m_preview_page)
+    if (m_preview_page) {
         m_preview_page_container->addWidget(previewPageWidget);
+        updatePreviewPage();
+    }
 
     m_preview_page_container->blockSignals(!visible);
     m_preview_page_container->setVisible(visible);
@@ -226,6 +230,10 @@ void TabWidget::setPreviewPage(Peony::PreviewPageIface *previewPage)
 
 void TabWidget::addPage(const QString &uri, bool jumpTo)
 {
+    QCursor c;
+    c.setShape(Qt::WaitCursor);
+    this->setCursor(c);
+
     m_tab_bar->addPage(uri, jumpTo);
     auto viewContainer = new Peony::DirectoryViewContainer(m_stack);
     viewContainer->setSortType(Peony::FileItemModel::FileName);

--- a/src/control/tab-widget.cpp
+++ b/src/control/tab-widget.cpp
@@ -340,6 +340,16 @@ void TabWidget::changeCurrentIndex(int index)
     Q_EMIT activePageChanged();
 }
 
+int TabWidget::count()
+{
+    return m_stack->count();
+}
+
+int TabWidget::currentIndex()
+{
+    return m_stack->currentIndex();
+}
+
 void TabWidget::moveTab(int from, int to)
 {
     auto w = m_stack->widget(from);

--- a/src/control/tab-widget.cpp
+++ b/src/control/tab-widget.cpp
@@ -335,7 +335,6 @@ void TabWidget::changeCurrentIndex(int index)
     m_tab_bar->setCurrentIndex(index);
     m_stack->setCurrentIndex(index);
     Q_EMIT currentIndexChanged(index);
-
     Q_EMIT activePageChanged();
 }
 
@@ -352,7 +351,11 @@ void TabWidget::moveTab(int from, int to)
 void TabWidget::removeTab(int index)
 {
     m_tab_bar->removeTab(index);
-    m_stack->removeWidget(m_stack->widget(index));
+    auto widget = m_stack->widget(index);
+    m_stack->removeWidget(widget);
+    widget->deleteLater();
+    if (m_stack->count() > 0)
+        Q_EMIT activePageChanged();
 }
 
 void TabWidget::bindContainerSignal(Peony::DirectoryViewContainer *container)

--- a/src/control/tab-widget.h
+++ b/src/control/tab-widget.h
@@ -1,3 +1,25 @@
+/*
+ * Peony-Qt
+ *
+ * Copyright (C) 2020, Tianjin KYLIN Information Technology Co., Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Authors: Yue Lan <lanyue@kylinos.cn>
+ *
+ */
+
 #ifndef TABWIDGET_H
 #define TABWIDGET_H
 
@@ -64,6 +86,8 @@ private:
 
     Peony::PreviewPageIface *m_preview_page = nullptr;
     QDockWidget *m_preview_page_container;
+
+    QAction *m_current_preview_action = nullptr;
 };
 
 class PreviewPageButtonGroups : public QButtonGroup

--- a/src/control/tab-widget.h
+++ b/src/control/tab-widget.h
@@ -1,0 +1,79 @@
+#ifndef TABWIDGET_H
+#define TABWIDGET_H
+
+#include <QMainWindow>
+#include <QButtonGroup>
+#include "navigation-tab-bar.h"
+
+class NavigationTabBar;
+class QStackedWidget;
+class PreviewPageButtonGroups;
+
+namespace Peony {
+class PreviewPageIface;
+}
+
+/*!
+ * \brief The TabWidget class
+ * \details
+ * TabWidget is different with QTabWidget, it contains 4 parts.
+ * 1. tabbar
+ * 2. stackwidget
+ * 3. preview button group
+ * 4. preview page
+ * <br>
+ * Tabbar and statck is simmilar to QTabWidget's. Preview page is a docked page
+ * which can be added or removed by preview button group.
+ */
+class TabWidget : public QMainWindow
+{
+    Q_OBJECT
+public:
+    explicit TabWidget(QWidget *parent = nullptr);
+
+    QTabBar *tabBar() {return m_tab_bar;}
+
+Q_SIGNALS:
+    void currentIndexChanged(int index);
+    void tabMoved(int from, int to);
+    void tabInserted(int index);
+    void tabRemoved(int index);
+
+    void activePageChanged();
+    void activePageLocationChanged();
+    void activePageViewTypeChanged();
+    void activePageViewSortTypeChanged();
+
+    void closeWindowRequest();
+
+public Q_SLOTS:
+    void setCurrentIndex(int index);
+    void setPreviewPage(Peony::PreviewPageIface *previewPage = nullptr);
+    void addPage(const QString &uri, bool jumpTo = false);
+
+protected:
+    void changeCurrentIndex(int index);
+    void moveTab(int from, int to);
+    void removeTab(int index);
+
+private:
+    NavigationTabBar *m_tab_bar;
+    QStackedWidget *m_stack;
+
+    PreviewPageButtonGroups *m_buttons;
+
+    Peony::PreviewPageIface *m_preview_page = nullptr;
+    QDockWidget *m_preview_page_container;
+};
+
+class PreviewPageButtonGroups : public QButtonGroup
+{
+    Q_OBJECT
+public:
+    explicit PreviewPageButtonGroups(QWidget *parent = nullptr);
+
+Q_SIGNALS:
+    void previewPageButtonTrigger(bool trigger, const QString &pluginId);
+};
+
+#endif // TABWIDGET_H

--- a/src/control/tab-widget.h
+++ b/src/control/tab-widget.h
@@ -33,6 +33,7 @@ class PreviewPageButtonGroups;
 
 namespace Peony {
 class PreviewPageIface;
+class DirectoryViewContainer;
 }
 
 /*!
@@ -55,16 +56,40 @@ public:
 
     QTabBar *tabBar() {return m_tab_bar;}
 
+    Peony::DirectoryViewContainer *currentPage();
+
+    const QString getCurrentUri();
+    const QStringList getCurrentSelections();
+
+    const QStringList getAllFileUris();
+
+    const QStringList getBackList();
+    const QStringList getForwardList();
+
+    bool canGoBack();
+    bool canGoForward();
+    bool canCdUp();
+
+    int getSortType();
+    Qt::SortOrder getSortOrder();
+
 Q_SIGNALS:
     void currentIndexChanged(int index);
     void tabMoved(int from, int to);
     void tabInserted(int index);
     void tabRemoved(int index);
 
+    void activePageSelectionChanged();
     void activePageChanged();
     void activePageLocationChanged();
     void activePageViewTypeChanged();
     void activePageViewSortTypeChanged();
+
+    void selectionChanged();
+    void viewDoubleClicked(const QString &uri);
+    void updateWindowLocationRequest(const QString &uri, bool addHistory, bool forceUpdate = false);
+
+    void menuRequest(const QPoint &pos);
 
     void closeWindowRequest();
 
@@ -73,10 +98,40 @@ public Q_SLOTS:
     void setPreviewPage(Peony::PreviewPageIface *previewPage = nullptr);
     void addPage(const QString &uri, bool jumpTo = false);
 
+    void goToUri(const QString &uri, bool addHistory, bool forceUpdate = false);
+    void switchViewType(const QString &viewId);
+
+    void goBack();
+    void goForward();
+    void cdUp();
+
+    void refresh();
+    void stopLoading();
+
+    void tryJump(int index);
+    void clearHistory();
+
+    void setSortType(int type);
+    void setSortOrder(Qt::SortOrder order);
+
+    void setSortFilter(int FileTypeIndex, int FileMTimeIndex, int FileSizeIndex);
+    void setShowHidden(bool showHidden = false);
+    void setUseDefaultNameSortOrder(bool use);
+    void setSortFolderFirst(bool folderFirst);
+
+    void setCurrentSelections(const QStringList &uris);
+
+    void editUri(const QString &uri);
+    void editUris(const QStringList &uris);
+
+    void onViewDoubleClicked(const QString &uri);
+
 protected:
     void changeCurrentIndex(int index);
     void moveTab(int from, int to);
     void removeTab(int index);
+
+    void bindContainerSignal(Peony::DirectoryViewContainer *container);
 
 private:
     NavigationTabBar *m_tab_bar;

--- a/src/control/tab-widget.h
+++ b/src/control/tab-widget.h
@@ -25,6 +25,7 @@
 
 #include <QMainWindow>
 #include <QButtonGroup>
+#include <QStackedWidget>
 #include "navigation-tab-bar.h"
 
 class NavigationTabBar;
@@ -85,7 +86,6 @@ Q_SIGNALS:
     void activePageViewTypeChanged();
     void activePageViewSortTypeChanged();
 
-    void selectionChanged();
     void viewDoubleClicked(const QString &uri);
     void updateWindowLocationRequest(const QString &uri, bool addHistory, bool forceUpdate = false);
 
@@ -135,6 +135,7 @@ protected:
     void moveTab(int from, int to);
 
     void bindContainerSignal(Peony::DirectoryViewContainer *container);
+    void updatePreviewPage();
 
 private:
     NavigationTabBar *m_tab_bar;
@@ -143,9 +144,17 @@ private:
     PreviewPageButtonGroups *m_buttons;
 
     Peony::PreviewPageIface *m_preview_page = nullptr;
-    QDockWidget *m_preview_page_container;
+    QStackedWidget *m_preview_page_container;
 
     QAction *m_current_preview_action = nullptr;
+};
+
+class PreviewPageContainer : public QStackedWidget
+{
+    friend class TabWidget;
+    Q_OBJECT
+    explicit PreviewPageContainer(QWidget *parent = nullptr);
+    QSize sizeHint() const {return QSize(200, QStackedWidget::sizeHint().height());}
 };
 
 class PreviewPageButtonGroups : public QButtonGroup

--- a/src/control/tab-widget.h
+++ b/src/control/tab-widget.h
@@ -126,10 +126,13 @@ public Q_SLOTS:
 
     void onViewDoubleClicked(const QString &uri);
 
+    int count();
+    int currentIndex();
+    void removeTab(int index);
+
 protected:
     void changeCurrentIndex(int index);
     void moveTab(int from, int to);
-    void removeTab(int index);
 
     void bindContainerSignal(Peony::DirectoryViewContainer *container);
 

--- a/src/control/view-type-menu.cpp
+++ b/src/control/view-type-menu.cpp
@@ -23,6 +23,7 @@
 #include "view-type-menu.h"
 
 #include "view-factory-sort-filter-model.h"
+#include "directory-view-factory-manager.h"
 
 #include <QActionGroup>
 
@@ -45,7 +46,8 @@ ViewTypeMenu::ViewTypeMenu(QWidget *parent) : QMenu(parent)
     });
 
     setCurrentDirectory("file:///");
-    setCurrentView(tr("Icon View"));
+    auto viewFactory = Peony::DirectoryViewFactoryManager2::getInstance();
+    setCurrentView(viewFactory->getDefaultViewId());
 }
 
 void ViewTypeMenu::setCurrentView(const QString &viewId)

--- a/src/control/view-type-menu.cpp
+++ b/src/control/view-type-menu.cpp
@@ -1,0 +1,100 @@
+/*
+ * Peony-Qt
+ *
+ * Copyright (C) 2020, Tianjin KYLIN Information Technology Co., Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Authors: Yue Lan <lanyue@kylinos.cn>
+ *
+ */
+
+#include "view-type-menu.h"
+
+#include "view-factory-sort-filter-model.h"
+
+#include <QActionGroup>
+
+#include <QDebug>
+
+ViewTypeMenu::ViewTypeMenu(QWidget *parent) : QMenu(parent)
+{
+    m_model = new Peony::ViewFactorySortFilterModel2(this);
+    m_view_actions = new QActionGroup(this);
+    m_view_actions->setExclusive(true);
+
+    connect(m_view_actions, &QActionGroup::triggered, this, [=](QAction *action){
+        auto viewId = action->text();
+        setCurrentView(viewId);
+    });
+
+    connect(this, &QMenu::aboutToShow, this, [=](){
+        qDebug()<<"show menu";
+        updateMenuActions();
+    });
+
+    setCurrentDirectory("file:///");
+    setCurrentView(tr("Icon View"));
+}
+
+void ViewTypeMenu::setCurrentView(const QString &viewId)
+{
+    if (viewId == m_current_view_id)
+        return;
+
+    if (isViewIdValid(viewId)) {
+        m_current_view_id = viewId;
+    }
+
+    for (auto action : m_view_actions->actions()) {
+        if (action->text() == viewId) {
+            action->setChecked(true);
+        }
+    }
+
+    Q_EMIT this->switchViewRequest(viewId, m_model->iconFromViewId(viewId));
+}
+
+void ViewTypeMenu::setCurrentDirectory(const QString &uri)
+{
+    m_current_uri = uri;
+    m_model->setDirectoryUri(uri);
+}
+
+bool ViewTypeMenu::isViewIdValid(const QString &viewId)
+{
+    return m_model->supportViewIds().contains(viewId);
+}
+
+void ViewTypeMenu::updateMenuActions()
+{
+    auto supportViews = m_model->supportViewIds();
+    for (auto action : m_view_actions->actions()) {
+        removeAction(action);
+        m_view_actions->removeAction(action);
+        action->deleteLater();
+    }
+    for (auto id : supportViews) {
+        auto action = new QAction(this);
+        action->setText(id);
+        action->setIcon(m_model->iconFromViewId(id));
+        m_view_actions->addAction(action);
+        addAction(action);
+
+        action->setCheckable(true);
+        if (m_current_view_id == id) {
+            action->setChecked(true);
+        }
+    }
+}

--- a/src/control/view-type-menu.h
+++ b/src/control/view-type-menu.h
@@ -1,0 +1,58 @@
+/*
+ * Peony-Qt
+ *
+ * Copyright (C) 2020, Tianjin KYLIN Information Technology Co., Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Authors: Yue Lan <lanyue@kylinos.cn>
+ *
+ */
+
+#ifndef VIEWTYPEMENU_H
+#define VIEWTYPEMENU_H
+
+#include <QMenu>
+
+namespace Peony {
+class ViewFactorySortFilterModel2;
+}
+
+class ViewTypeMenu : public QMenu
+{
+    Q_OBJECT
+public:
+    explicit ViewTypeMenu(QWidget *parent = nullptr);
+
+Q_SIGNALS:
+    void switchViewRequest(const QString &viewId, const QIcon &icon);
+
+public Q_SLOTS:
+    void setCurrentView(const QString &viewId);
+    void setCurrentDirectory(const QString &uri);
+
+protected:
+    bool isViewIdValid(const QString &viewId);
+    void updateMenuActions();
+
+private:
+    QString m_current_uri;
+
+    QString m_current_view_id;
+    Peony::ViewFactorySortFilterModel2 *m_model;
+
+    QActionGroup *m_view_actions;
+};
+
+#endif // VIEWTYPEMENU_H

--- a/src/peony-application.cpp
+++ b/src/peony-application.cpp
@@ -94,6 +94,7 @@
 #include <QLocale>
 
 #include <QStyleFactory>
+#include <QDesktopServices>
 
 PeonyApplication::PeonyApplication(int &argc, char *argv[], const char *applicationName) : SingleApplication (argc, argv, applicationName, true)
 {
@@ -536,4 +537,21 @@ void PeonyApplication::parseCmd(quint32 id, QByteArray msg)
             window->show();
         }
     }
+}
+
+void PeonyApplication::about()
+{
+    QMessageBox::about(nullptr,
+                       tr("Peony Qt"),
+                       tr("Authour: \n"
+                          "\tYue Lan <lanyue@kylinos.cn>\n"
+                          "\tMeihong He <hemeihong@kylinos.cn>\n"
+                          "\n"
+                          "Copyright (C): 2019-2020, Tianjin KYLIN Information Technology Co., Ltd."));
+}
+
+void PeonyApplication::help()
+{
+    QUrl url = QUrl("help:ubuntu-kylin-help/files", QUrl::TolerantMode);
+    QDesktopServices::openUrl(url);
 }

--- a/src/peony-application.cpp
+++ b/src/peony-application.cpp
@@ -101,6 +101,12 @@ PeonyApplication::PeonyApplication(int &argc, char *argv[], const char *applicat
     setApplicationName("peony-qt");
     //setApplicationDisplayName(tr("Peony-Qt"));
 
+    QFile file(":/data/libpeony-qt-styled.qss");
+    file.open(QFile::ReadOnly);
+    setStyleSheet(QString::fromLatin1(file.readAll()));
+    //qDebug()<<file.readAll();
+    file.close();
+
     QTranslator *t = new QTranslator(this);
     qDebug()<<"\n\n\n\n\n\n\ntranslate:"<<t->load("/usr/share/libpeony-qt/libpeony-qt_"+QLocale::system().name());
     QApplication::installTranslator(t);
@@ -159,14 +165,8 @@ PeonyApplication::PeonyApplication(int &argc, char *argv[], const char *applicat
     }
     Peony::SearchVFSRegister::registSearchVFS();
     //QIcon::setThemeName("ukui-icon-theme-one");
-    setAttribute(Qt::AA_UseHighDpiPixmaps);
+    //setAttribute(Qt::AA_UseHighDpiPixmaps);
     //setAttribute(Qt::AA_EnableHighDpiScaling);
-
-    QFile file(":/data/libpeony-qt-styled.qss");
-    file.open(QFile::ReadOnly);
-    setStyleSheet(QString::fromLatin1(file.readAll()));
-    //qDebug()<<file.readAll();
-    file.close();
 
     //setStyle(QStyleFactory::create("windows"));
 

--- a/src/peony-application.cpp
+++ b/src/peony-application.cpp
@@ -63,6 +63,7 @@
 #include "navigation-bar.h"
 
 #include "fm-window.h"
+#include "main-window.h"
 
 #include <QFile>
 
@@ -489,8 +490,9 @@ void PeonyApplication::parseCmd(quint32 id, QByteArray msg)
             auto parentUris = itemHash.keys();
 
             for (auto parentUri : parentUris) {
-                Peony::FMWindow *window = new Peony::FMWindow(parentUri);
-                connect(window, &Peony::FMWindow::locationChangeEnd, [=](){
+                auto window = new MainWindow(parentUri);
+                //Peony::FMWindow *window = new Peony::FMWindow(parentUri);
+                connect(window, &MainWindow::locationChangeEnd, [=](){
                     QTimer::singleShot(500, [=]{
                         window->getCurrentPage()->getView()->setSelections(itemHash.value(parentUri));
                         window->getCurrentPage()->getView()->scrollToSelection(itemHash.value(parentUri).first());
@@ -502,7 +504,8 @@ void PeonyApplication::parseCmd(quint32 id, QByteArray msg)
 
         if (parser.isSet(showFoldersOption)) {
             QStringList uris = Peony::FileUtils::toDisplayUris(parser.positionalArguments());
-            Peony::FMWindow *window = new Peony::FMWindow(uris.first());
+            auto window = new MainWindow(uris.first());
+            //Peony::FMWindow *window = new Peony::FMWindow(uris.first());
             uris.removeAt(0);
             if (!uris.isEmpty()) {
                 window->addNewTabs(uris);
@@ -518,7 +521,8 @@ void PeonyApplication::parseCmd(quint32 id, QByteArray msg)
     } else {
         if (!parser.positionalArguments().isEmpty()) {
             QStringList uris = Peony::FileUtils::toDisplayUris(parser.positionalArguments());
-            auto window = new Peony::FMWindow(uris.first());
+            //auto window = new Peony::FMWindow(uris.first());
+            auto window = new MainWindow(uris.first());
             uris.removeAt(0);
             if (!uris.isEmpty()) {
                 window->addNewTabs(uris);
@@ -526,7 +530,8 @@ void PeonyApplication::parseCmd(quint32 id, QByteArray msg)
             window->setAttribute(Qt::WA_DeleteOnClose);
             window->show();
         } else {
-            auto window = new Peony::FMWindow;
+            auto window = new MainWindow;
+            //auto window = new Peony::FMWindow;
             window->setAttribute(Qt::WA_DeleteOnClose);
             window->show();
         }

--- a/src/peony-application.h
+++ b/src/peony-application.h
@@ -44,6 +44,8 @@ class PeonyApplication : public SingleApplication
     Q_OBJECT
 public:
     explicit PeonyApplication(int &argc, char *argv[], const char *applicationName = "peony-qt");
+    static void about();
+    static void help();
 
 protected Q_SLOTS:
     void parseCmd(quint32 id, QByteArray msg);

--- a/src/peony-main-window-style.cpp
+++ b/src/peony-main-window-style.cpp
@@ -1,0 +1,38 @@
+#include "peony-main-window-style.h"
+
+static PeonyMainWindowStyle *global_instance = nullptr;
+
+PeonyMainWindowStyle *PeonyMainWindowStyle::getStyle()
+{
+    if (!global_instance) {
+        global_instance = new PeonyMainWindowStyle;
+    }
+    return global_instance;
+}
+
+PeonyMainWindowStyle::PeonyMainWindowStyle(QObject *parent) : QProxyStyle()
+{
+
+}
+
+int PeonyMainWindowStyle::pixelMetric(QStyle::PixelMetric metric, const QStyleOption *option, const QWidget *widget) const
+{
+    switch (metric) {
+    case PM_LayoutVerticalSpacing:
+    case PM_LayoutTopMargin:
+    case PM_LayoutLeftMargin:
+    case PM_LayoutRightMargin:
+    case PM_LayoutBottomMargin:
+    case PM_LayoutHorizontalSpacing:
+    case PM_DockWidgetFrameWidth:
+    case PM_DockWidgetTitleMargin:
+    case PM_DockWidgetTitleBarButtonMargin:
+        return 0;
+    case PM_DockWidgetHandleExtent:
+        return 2;
+    case PM_DockWidgetSeparatorExtent:
+        return 2;
+    default:
+        return QProxyStyle::pixelMetric(metric, option, widget);
+    }
+}

--- a/src/peony-main-window-style.cpp
+++ b/src/peony-main-window-style.cpp
@@ -1,3 +1,25 @@
+/*
+ * Peony-Qt
+ *
+ * Copyright (C) 2020, Tianjin KYLIN Information Technology Co., Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Authors: Yue Lan <lanyue@kylinos.cn>
+ *
+ */
+
 #include "peony-main-window-style.h"
 
 static PeonyMainWindowStyle *global_instance = nullptr;

--- a/src/peony-main-window-style.h
+++ b/src/peony-main-window-style.h
@@ -1,0 +1,19 @@
+#ifndef PEONYMAINWINDOWSTYLE_H
+#define PEONYMAINWINDOWSTYLE_H
+
+#include <QProxyStyle>
+
+class PeonyMainWindowStyle : public QProxyStyle
+{
+    Q_OBJECT
+public:
+    static PeonyMainWindowStyle *getStyle();
+
+private:
+    explicit PeonyMainWindowStyle(QObject *parent = nullptr);
+
+    int pixelMetric(PixelMetric metric, const QStyleOption *option = nullptr, const QWidget *widget = nullptr) const override;
+
+};
+
+#endif // PEONYMAINWINDOWSTYLE_H

--- a/src/peony-main-window-style.h
+++ b/src/peony-main-window-style.h
@@ -1,3 +1,25 @@
+/*
+ * Peony-Qt
+ *
+ * Copyright (C) 2020, Tianjin KYLIN Information Technology Co., Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Authors: Yue Lan <lanyue@kylinos.cn>
+ *
+ */
+
 #ifndef PEONYMAINWINDOWSTYLE_H
 #define PEONYMAINWINDOWSTYLE_H
 

--- a/src/peony-main.cpp
+++ b/src/peony-main.cpp
@@ -31,6 +31,8 @@
 
 #include <QStandardPaths>
 
+#include "navigation-tab-bar.h"
+
 void messageOutput(QtMsgType type, const QMessageLogContext &context, const QString &msg)
 {
     QByteArray localMsg = msg.toLocal8Bit();
@@ -80,6 +82,11 @@ int main(int argc, char *argv[]) {
     QApplication a(argc, argv);
         MainWindow w;
         w.show();
+        NavigationTabBar t;
+        t.connect(&t, &NavigationTabBar::closeWindowRequest, [&](){
+            t.close();
+        });
+        t.show();
     return a.exec();
     PeonyApplication app(argc, argv, "peony-qt");
     if (app.isSecondary())

--- a/src/peony-main.cpp
+++ b/src/peony-main.cpp
@@ -22,6 +22,8 @@
 
 #include "peony-application.h"
 
+#include "main-window.h"
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <QTime>
@@ -75,6 +77,10 @@ void messageOutput(QtMsgType type, const QMessageLogContext &context, const QStr
 int main(int argc, char *argv[]) {
     qInstallMessageHandler(messageOutput);
     QGuiApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
+    QApplication a(argc, argv);
+        MainWindow w;
+        w.show();
+    return a.exec();
     PeonyApplication app(argc, argv, "peony-qt");
     if (app.isSecondary())
         return 0;

--- a/src/peony-main.cpp
+++ b/src/peony-main.cpp
@@ -32,6 +32,7 @@
 #include <QStandardPaths>
 
 #include "navigation-tab-bar.h"
+#include "tab-widget.h"
 
 void messageOutput(QtMsgType type, const QMessageLogContext &context, const QString &msg)
 {
@@ -82,11 +83,11 @@ int main(int argc, char *argv[]) {
     QApplication a(argc, argv);
         MainWindow w;
         w.show();
-        NavigationTabBar t;
-        t.connect(&t, &NavigationTabBar::closeWindowRequest, [&](){
-            t.close();
-        });
-        t.show();
+//        NavigationTabBar t;
+//        t.connect(&t, &NavigationTabBar::closeWindowRequest, [&](){
+//            t.close();
+//        });
+//        t.show();
     return a.exec();
     PeonyApplication app(argc, argv, "peony-qt");
     if (app.isSecondary())

--- a/src/peony-main.cpp
+++ b/src/peony-main.cpp
@@ -83,11 +83,6 @@ int main(int argc, char *argv[]) {
     QApplication a(argc, argv);
         MainWindow w;
         w.show();
-//        NavigationTabBar t;
-//        t.connect(&t, &NavigationTabBar::closeWindowRequest, [&](){
-//            t.close();
-//        });
-//        t.show();
     return a.exec();
     PeonyApplication app(argc, argv, "peony-qt");
     if (app.isSecondary())

--- a/src/peony-main.cpp
+++ b/src/peony-main.cpp
@@ -75,7 +75,7 @@ void messageOutput(QtMsgType type, const QMessageLogContext &context, const QStr
 }
 
 int main(int argc, char *argv[]) {
-    qInstallMessageHandler(messageOutput);
+    //qInstallMessageHandler(messageOutput);
     QGuiApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
     QApplication a(argc, argv);
         MainWindow w;

--- a/src/peony-main.cpp
+++ b/src/peony-main.cpp
@@ -78,7 +78,7 @@ void messageOutput(QtMsgType type, const QMessageLogContext &context, const QStr
 }
 
 int main(int argc, char *argv[]) {
-    //qInstallMessageHandler(messageOutput);
+    qInstallMessageHandler(messageOutput);
     //QGuiApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
     //QGuiApplication::setAttribute(Qt::AA_UseHighDpiPixmaps);
 

--- a/src/peony-main.cpp
+++ b/src/peony-main.cpp
@@ -79,8 +79,8 @@ void messageOutput(QtMsgType type, const QMessageLogContext &context, const QStr
 
 int main(int argc, char *argv[]) {
     //qInstallMessageHandler(messageOutput);
-    QGuiApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
-    QGuiApplication::setAttribute(Qt::AA_UseHighDpiPixmaps);
+    //QGuiApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
+    //QGuiApplication::setAttribute(Qt::AA_UseHighDpiPixmaps);
 
     PeonyApplication app(argc, argv, "peony-qt");
     if (app.isSecondary())

--- a/src/peony-main.cpp
+++ b/src/peony-main.cpp
@@ -80,6 +80,7 @@ void messageOutput(QtMsgType type, const QMessageLogContext &context, const QStr
 int main(int argc, char *argv[]) {
     //qInstallMessageHandler(messageOutput);
     QGuiApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
+    QGuiApplication::setAttribute(Qt::AA_UseHighDpiPixmaps);
     QApplication a(argc, argv);
         MainWindow w;
         w.show();

--- a/src/peony-main.cpp
+++ b/src/peony-main.cpp
@@ -81,10 +81,7 @@ int main(int argc, char *argv[]) {
     //qInstallMessageHandler(messageOutput);
     QGuiApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
     QGuiApplication::setAttribute(Qt::AA_UseHighDpiPixmaps);
-    QApplication a(argc, argv);
-        MainWindow w;
-        w.show();
-    return a.exec();
+
     PeonyApplication app(argc, argv, "peony-qt");
     if (app.isSecondary())
         return 0;

--- a/src/src.pro
+++ b/src/src.pro
@@ -4,9 +4,9 @@
 #
 #-------------------------------------------------
 
-QT       += core gui
+QT       += core gui gui-private
 
-greaterThan(QT_MAJOR_VERSION, 4): QT += widgets
+greaterThan(QT_MAJOR_VERSION, 4): QT += widgets widgets-private
 
 VERSION = 2.0.0
 
@@ -16,6 +16,7 @@ TEMPLATE = app
 
 include(../libpeony-qt/libpeony-qt-header.pri)
 include(../3rd-parties/SingleApplication/singleapplication.pri)
+include(windows/windows.pri)
 DEFINES += QAPPLICATION_CLASS=QApplication
 
 PKGCONFIG +=gio-2.0 glib-2.0 gio-unix-2.0

--- a/src/src.pro
+++ b/src/src.pro
@@ -42,10 +42,12 @@ TRANSLATIONS += ../translations/peony-qt/peony-qt_zh_CN.ts
 
 SOURCES += \
     peony-application.cpp \
+    peony-main-window-style.cpp \
     peony-main.cpp \
 
 HEADERS += \
-    peony-application.h \
+    peony-application.h \ \
+    peony-main-window-style.h
 
 INCLUDEPATH    += ../plugin-iface
 

--- a/src/src.pro
+++ b/src/src.pro
@@ -4,7 +4,7 @@
 #
 #-------------------------------------------------
 
-QT       += core gui gui-private
+QT       += core gui gui-private x11extras
 
 greaterThan(QT_MAJOR_VERSION, 4): QT += widgets widgets-private
 

--- a/src/src.pro
+++ b/src/src.pro
@@ -17,6 +17,8 @@ TEMPLATE = app
 include(../libpeony-qt/libpeony-qt-header.pri)
 include(../3rd-parties/SingleApplication/singleapplication.pri)
 include(windows/windows.pri)
+include(control/control.pri)
+include(view/view.pri)
 DEFINES += QAPPLICATION_CLASS=QApplication
 
 PKGCONFIG +=gio-2.0 glib-2.0 gio-unix-2.0

--- a/src/src.pro
+++ b/src/src.pro
@@ -18,7 +18,7 @@ include(../libpeony-qt/libpeony-qt-header.pri)
 include(../3rd-parties/SingleApplication/singleapplication.pri)
 include(windows/windows.pri)
 include(control/control.pri)
-include(view/view.pri)
+#include(view/view.pri)
 DEFINES += QAPPLICATION_CLASS=QApplication
 
 PKGCONFIG +=gio-2.0 glib-2.0 gio-unix-2.0

--- a/src/windows/main-window-factory.cpp
+++ b/src/windows/main-window-factory.cpp
@@ -1,0 +1,56 @@
+/*
+ * Peony-Qt
+ *
+ * Copyright (C) 2020, Tianjin KYLIN Information Technology Co., Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Authors: Yue Lan <lanyue@kylinos.cn>
+ *
+ */
+
+#include "main-window-factory.h"
+#include "main-window.h"
+
+MainWindowFactory *global_instance = nullptr;
+
+Peony::FMWindowFactory *MainWindowFactory::getInstance()
+{
+    if (!global_instance)
+        global_instance = new MainWindowFactory;
+    return global_instance;
+}
+
+Peony::FMWindowIface *MainWindowFactory::create(const QString &uri)
+{
+    auto window = new MainWindow(uri);
+    return window;
+}
+
+Peony::FMWindowIface *MainWindowFactory::create(const QStringList &uris)
+{
+    if (uris.isEmpty())
+        return new MainWindow;
+    auto uri = uris.first();
+    auto l = uris;
+    l.removeAt(0);
+    auto window = new MainWindow(uri);
+    window->addNewTabs(l);
+    return window;
+}
+
+MainWindowFactory::MainWindowFactory(QObject *parent) : Peony::FMWindowFactory(parent)
+{
+
+}

--- a/src/windows/main-window-factory.h
+++ b/src/windows/main-window-factory.h
@@ -1,0 +1,42 @@
+/*
+ * Peony-Qt
+ *
+ * Copyright (C) 2020, Tianjin KYLIN Information Technology Co., Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Authors: Yue Lan <lanyue@kylinos.cn>
+ *
+ */
+
+#ifndef MAINWINDOWFACTORY_H
+#define MAINWINDOWFACTORY_H
+
+#include <QObject>
+#include "fm-window-factory.h"
+
+class MainWindowFactory : public Peony::FMWindowFactory
+{
+    Q_OBJECT
+public:
+    static Peony::FMWindowFactory *getInstance();
+
+    Peony::FMWindowIface *create(const QString &uri);
+    Peony::FMWindowIface *create(const QStringList &uris);
+
+private:
+    explicit MainWindowFactory(QObject *parent = nullptr);
+};
+
+#endif // MAINWINDOWFACTORY_H

--- a/src/windows/main-window.cpp
+++ b/src/windows/main-window.cpp
@@ -37,7 +37,7 @@
 #include "side-bar-model.h"
 
 #include "directory-view-container.h"
-#include "tab-page.h"
+#include "tab-widget.h"
 #include "x11-window-manager.h"
 
 #include "navigation-side-bar.h"
@@ -201,10 +201,11 @@ void MainWindow::initUI()
     sidebarContainer->setWidget(sidebar);
     addDockWidget(Qt::LeftDockWidgetArea, sidebarContainer);
 
-    Peony::TabPage *views = new Peony::TabPage(this);
-    views->setTabBarAutoHide(false);
+    auto views = new TabWidget;
     views->addPage("file:///");
     views->addPage("file:///home");
+
+    connect(views, &TabWidget::closeWindowRequest, this, &QWidget::close);
 
     X11WindowManager *tabBarHandler = X11WindowManager::getInstance();
     tabBarHandler->registerWidget(views->tabBar());

--- a/src/windows/main-window.cpp
+++ b/src/windows/main-window.cpp
@@ -1,0 +1,78 @@
+/*
+ * Peony-Qt's Library
+ *
+ * Copyright (C) 2020, Tianjin KYLIN Information Technology Co., Ltd.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this library.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Authors: Yue Lan <lanyue@kylinos.cn>
+ *
+ */
+
+#include "main-window.h"
+
+#include "border-shadow-effect.h"
+#include <private/qwidgetresizehandler_p.h>
+
+#include <QVariant>
+
+MainWindow::MainWindow(QWidget *parent) : QMainWindow(parent)
+{
+    m_effect = new BorderShadowEffect(this);
+    m_effect->setPadding(4);
+    m_effect->setBorderRadius(6);
+    m_effect->setBlurRadius(4);
+    setGraphicsEffect(m_effect);
+
+    setAttribute(Qt::WA_TranslucentBackground);
+    setWindowFlag(Qt::FramelessWindowHint);
+    setContentsMargins(4, 4, 4, 4);
+
+    //bind resize handler
+    auto handler = new QWidgetResizeHandler(this);
+    handler->setMovingEnabled(false);
+}
+
+void MainWindow::resizeEvent(QResizeEvent *e)
+{
+    validBorder();
+    update();
+    QMainWindow::resizeEvent(e);
+}
+
+void MainWindow::paintEvent(QPaintEvent *e)
+{
+    validBorder();
+    QColor color = this->palette().base().color();
+    color.setAlphaF(0.5);
+    m_effect->setWindowBackground(color);
+    QMainWindow::paintEvent(e);
+}
+
+void MainWindow::validBorder()
+{
+    if (this->isMaximized()) {
+        setContentsMargins(0, 0, 0, 0);
+        m_effect->setPadding(0);
+        setProperty("blurRegion", QVariant());
+    } else {
+        setContentsMargins(4, 4, 4, 4);
+        m_effect->setPadding(4);
+        QPainterPath path;
+        auto rect = this->rect();
+        rect.adjust(4, 4, -4, -4);
+        path.addRoundedRect(rect, 6, 6);
+        setProperty("blurRegion", QRegion(path.toFillPolygon().toPolygon()));
+    }
+}

--- a/src/windows/main-window.cpp
+++ b/src/windows/main-window.cpp
@@ -88,7 +88,7 @@ void MainWindow::paintEvent(QPaintEvent *e)
 
 void MainWindow::mousePressEvent(QMouseEvent *e)
 {
-    qDebug()<<"mouse pressed";
+    //qDebug()<<"mouse pressed"<<e;
     QMainWindow::mousePressEvent(e);
     if (e->button() == Qt::LeftButton && !e->isAccepted())
         m_is_draging = true;
@@ -99,7 +99,7 @@ void MainWindow::mouseMoveEvent(QMouseEvent *e)
     //NOTE: when starting a X11 window move, the mouse move event
     //will unreachable when draging, and after draging we could not
     //get the release event correctly.
-    qDebug()<<"mouse move";
+    //qDebug()<<"mouse move";
     QMainWindow::mouseMoveEvent(e);
     if (!m_is_draging)
         return;
@@ -137,7 +137,7 @@ void MainWindow::mouseReleaseEvent(QMouseEvent *e)
      * X11 window manager for movement.
      */
     QMainWindow::mouseReleaseEvent(e);
-    qDebug()<<"mouse released";
+    //qDebug()<<"mouse released";
     m_is_draging = false;
 }
 

--- a/src/windows/main-window.cpp
+++ b/src/windows/main-window.cpp
@@ -1,33 +1,36 @@
 /*
- * Peony-Qt's Library
+ * Peony-Qt
  *
  * Copyright (C) 2020, Tianjin KYLIN Information Technology Co., Ltd.
  *
- * This library is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
  *
- * This library is distributed in the hope that it will be useful,
+ * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this library.  If not, see <https://www.gnu.org/licenses/>.
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  *
  * Authors: Yue Lan <lanyue@kylinos.cn>
  *
  */
 
 #include "main-window.h"
+#include "header-bar.h"
 
 #include "border-shadow-effect.h"
 #include <private/qwidgetresizehandler_p.h>
 
 #include <QVariant>
 
-MainWindow::MainWindow(QWidget *parent) : QMainWindow(parent)
+#include <QTreeWidget>
+
+MainWindow::MainWindow(const QString &uri, QWidget *parent) : QMainWindow(parent)
 {
     m_effect = new BorderShadowEffect(this);
     m_effect->setPadding(4);
@@ -35,13 +38,29 @@ MainWindow::MainWindow(QWidget *parent) : QMainWindow(parent)
     m_effect->setBlurRadius(4);
     setGraphicsEffect(m_effect);
 
+    setAnimated(false);
     setAttribute(Qt::WA_TranslucentBackground);
+    setAttribute(Qt::WA_OpaquePaintEvent);
     setWindowFlag(Qt::FramelessWindowHint);
     setContentsMargins(4, 4, 4, 4);
 
     //bind resize handler
     auto handler = new QWidgetResizeHandler(this);
     handler->setMovingEnabled(false);
+
+    //init UI
+    initUI();
+}
+
+void MainWindow::syncControlsLocation(const QString &uri)
+{
+    //FIXME:
+}
+
+void MainWindow::goToUri(const QString &uri, bool addHistory, bool force)
+{
+    //FIXME:
+    //go to uri
 }
 
 void MainWindow::resizeEvent(QResizeEvent *e)
@@ -75,4 +94,10 @@ void MainWindow::validBorder()
         path.addRoundedRect(rect, 6, 6);
         setProperty("blurRegion", QRegion(path.toFillPolygon().toPolygon()));
     }
+}
+
+void MainWindow::initUI()
+{
+    auto headerBar = new HeaderBar(this);
+    addToolBar(headerBar);
 }

--- a/src/windows/main-window.cpp
+++ b/src/windows/main-window.cpp
@@ -100,8 +100,8 @@ void MainWindow::resizeEvent(QResizeEvent *e)
 void MainWindow::paintEvent(QPaintEvent *e)
 {
     validBorder();
-    QColor color = this->palette().base().color();
-    color.setAlphaF(0.5);
+    QColor color = this->palette().window().color();
+    //color.setAlphaF(0.5);
     m_effect->setWindowBackground(color);
     QPainter p(this);
     m_effect->drawWindowShadowManually(&p, this->rect());

--- a/src/windows/main-window.cpp
+++ b/src/windows/main-window.cpp
@@ -105,6 +105,11 @@ void MainWindow::paintEvent(QPaintEvent *e)
 {
     validBorder();
     QColor color = this->palette().window().color();
+
+    QPainterPath sidebarPath;
+    sidebarPath.addRect(sideBarRect());
+    m_effect->setTransParentPath(sidebarPath);
+
     //color.setAlphaF(0.5);
     m_effect->setWindowBackground(color);
     QPainter p(this);
@@ -207,6 +212,7 @@ void MainWindow::initUI()
     sidebarContainer->setAttribute(Qt::WA_TranslucentBackground);
     sidebarContainer->setContentsMargins(0, 0, 0, 0);
     NavigationSideBar *sidebar = new NavigationSideBar(this);
+    m_side_bar = sidebar;
 
     auto labelDialog = new FileLabelBox(this);
     labelDialog->hide();
@@ -231,4 +237,10 @@ void MainWindow::initUI()
     tabBarHandler->registerWidget(views->tabBar());
 
     setCentralWidget(views);
+}
+
+QRect MainWindow::sideBarRect()
+{
+    auto pos = m_side_bar->mapTo(this, QPoint());
+    return QRect(pos, m_side_bar->size());
 }

--- a/src/windows/main-window.cpp
+++ b/src/windows/main-window.cpp
@@ -206,7 +206,7 @@ void MainWindow::initUI()
     views->addPage("file:///");
     views->addPage("file:///home");
 
-    X11WindowManager *tabBarHandler = new X11WindowManager(this);
+    X11WindowManager *tabBarHandler = X11WindowManager::getInstance();
     tabBarHandler->registerWidget(views->tabBar());
 
     setCentralWidget(views);

--- a/src/windows/main-window.cpp
+++ b/src/windows/main-window.cpp
@@ -185,10 +185,13 @@ void MainWindow::initUI()
 
     //SideBar
     QDockWidget *sidebarContainer = new QDockWidget(this);
-    sidebarContainer->setStyleSheet("{"
-                                    "background-color: transparent;"
-                                    "border: 0px solid transparent"
-                                    "}");
+    auto palette = sidebarContainer->palette();
+    palette.setColor(QPalette::Window, Qt::transparent);
+    sidebarContainer->setPalette(palette);
+//    sidebarContainer->setStyleSheet("{"
+//                                    "background-color: transparent;"
+//                                    "border: 0px solid transparent"
+//                                    "}");
     sidebarContainer->setTitleBarWidget(new QWidget(this));
     sidebarContainer->titleBarWidget()->setFixedHeight(0);
     sidebarContainer->setAttribute(Qt::WA_TranslucentBackground);

--- a/src/windows/main-window.cpp
+++ b/src/windows/main-window.cpp
@@ -50,6 +50,7 @@
 
 MainWindow::MainWindow(const QString &uri, QWidget *parent) : QMainWindow(parent)
 {
+    setMinimumWidth(600);
     m_effect = new BorderShadowEffect(this);
     m_effect->setPadding(4);
     m_effect->setBorderRadius(6);
@@ -188,7 +189,7 @@ void MainWindow::initUI()
                                     "background-color: transparent;"
                                     "border: 0px solid transparent"
                                     "}");
-    sidebarContainer->setTitleBarWidget(new QWidget);
+    sidebarContainer->setTitleBarWidget(new QWidget(this));
     sidebarContainer->titleBarWidget()->setFixedHeight(0);
     sidebarContainer->setAttribute(Qt::WA_TranslucentBackground);
     sidebarContainer->setContentsMargins(0, 0, 0, 0);

--- a/src/windows/main-window.cpp
+++ b/src/windows/main-window.cpp
@@ -42,6 +42,8 @@
 
 #include "navigation-side-bar.h"
 
+#include "peony-main-window-style.h"
+
 #include <QPainter>
 
 #include <QDebug>
@@ -50,6 +52,8 @@
 
 MainWindow::MainWindow(const QString &uri, QWidget *parent) : QMainWindow(parent)
 {
+    setStyle(PeonyMainWindowStyle::getStyle());
+
     setMinimumWidth(600);
     m_effect = new BorderShadowEffect(this);
     m_effect->setPadding(4);

--- a/src/windows/main-window.cpp
+++ b/src/windows/main-window.cpp
@@ -64,7 +64,7 @@ MainWindow::MainWindow(const QString &uri, QWidget *parent) : QMainWindow(parent
     setAnimated(false);
     //setAttribute(Qt::WA_DeleteOnClose); //double free, why?
     setAttribute(Qt::WA_TranslucentBackground);
-    setAttribute(Qt::WA_OpaquePaintEvent);
+    //setAttribute(Qt::WA_OpaquePaintEvent);
     setWindowFlag(Qt::FramelessWindowHint);
     setContentsMargins(4, 4, 4, 4);
 

--- a/src/windows/main-window.cpp
+++ b/src/windows/main-window.cpp
@@ -44,6 +44,10 @@
 
 #include "peony-main-window-style.h"
 
+#include "file-label-box.h"
+
+#include <QSplitter>
+
 #include <QPainter>
 
 #include <QDebug>
@@ -189,6 +193,8 @@ void MainWindow::initUI()
 
     //SideBar
     QDockWidget *sidebarContainer = new QDockWidget(this);
+
+    sidebarContainer->setFeatures(QDockWidget::NoDockWidgetFeatures);
     auto palette = sidebarContainer->palette();
     palette.setColor(QPalette::Window, Qt::transparent);
     sidebarContainer->setPalette(palette);
@@ -202,7 +208,17 @@ void MainWindow::initUI()
     sidebarContainer->setContentsMargins(0, 0, 0, 0);
     NavigationSideBar *sidebar = new NavigationSideBar(this);
 
-    sidebarContainer->setWidget(sidebar);
+    auto labelDialog = new FileLabelBox(this);
+    labelDialog->hide();
+
+    auto splitter = new QSplitter(this);
+    splitter->setHandleWidth(0);
+    splitter->addWidget(sidebar);
+    splitter->addWidget(labelDialog);
+
+    connect(sidebar, &NavigationSideBar::labelButtonClicked, labelDialog, &QWidget::setVisible);
+
+    sidebarContainer->setWidget(splitter);
     addDockWidget(Qt::LeftDockWidgetArea, sidebarContainer);
 
     auto views = new TabWidget;

--- a/src/windows/main-window.cpp
+++ b/src/windows/main-window.cpp
@@ -196,7 +196,7 @@ void MainWindow::initUI()
     sidebarContainer->titleBarWidget()->setFixedHeight(0);
     sidebarContainer->setAttribute(Qt::WA_TranslucentBackground);
     sidebarContainer->setContentsMargins(0, 0, 0, 0);
-    SideBar *sidebar = new SideBar(this);
+    NavigationSideBar *sidebar = new NavigationSideBar(this);
 
     sidebarContainer->setWidget(sidebar);
     addDockWidget(Qt::LeftDockWidgetArea, sidebarContainer);

--- a/src/windows/main-window.cpp
+++ b/src/windows/main-window.cpp
@@ -324,12 +324,14 @@ void MainWindow::initUI(const QString &uri)
         QCursor c;
         c.setShape(Qt::WaitCursor);
         this->setCursor(c);
+        m_tab->setCursor(c);
     });
 
     connect(this, &MainWindow::locationChangeEnd, this, [=](){
         QCursor c;
         c.setShape(Qt::ArrowCursor);
         this->setCursor(c);
+        m_tab->setCursor(c);
         updateHeaderBar();
     });
 

--- a/src/windows/main-window.cpp
+++ b/src/windows/main-window.cpp
@@ -78,6 +78,7 @@ MainWindow::MainWindow(const QString &uri, QWidget *parent) : QMainWindow(parent
     //bind resize handler
     auto handler = new QWidgetResizeHandler(this);
     handler->setMovingEnabled(false);
+    m_resize_handler = handler;
 
     //disable style window manager
     setProperty("useStyleWindowManager", false);
@@ -213,6 +214,11 @@ void MainWindow::resizeEvent(QResizeEvent *e)
     QMainWindow::resizeEvent(e);
 }
 
+/*!
+ * \note
+ * The window has a noticeable tearing effect due to the drawing of shadow effects.
+ * I should consider do not painting a shadow when resizing.
+ */
 void MainWindow::paintEvent(QPaintEvent *e)
 {
     validBorder();
@@ -225,7 +231,8 @@ void MainWindow::paintEvent(QPaintEvent *e)
     //color.setAlphaF(0.5);
     m_effect->setWindowBackground(color);
     QPainter p(this);
-    m_effect->drawWindowShadowManually(&p, this->rect());
+
+    m_effect->drawWindowShadowManually(&p, this->rect(), m_resize_handler->isButtonDown());
     QMainWindow::paintEvent(e);
 }
 
@@ -321,6 +328,7 @@ void MainWindow::initUI()
     addToolBar(headerBar);
 
     connect(m_header_bar, &HeaderBar::updateLocationRequest, this, &MainWindow::goToUri);
+    connect(m_header_bar, &HeaderBar::viewTypeChangeRequest, this, &MainWindow::beginSwitchView);
 
     //SideBar
     QDockWidget *sidebarContainer = new QDockWidget(this);

--- a/src/windows/main-window.cpp
+++ b/src/windows/main-window.cpp
@@ -78,7 +78,7 @@ MainWindow::MainWindow(const QString &uri, QWidget *parent) : QMainWindow(parent
 
     setStyle(PeonyMainWindowStyle::getStyle());
 
-    setMinimumWidth(600);
+    setMinimumWidth(750);
     m_effect = new BorderShadowEffect(this);
     m_effect->setPadding(4);
     m_effect->setBorderRadius(6);
@@ -644,6 +644,7 @@ void MainWindow::initUI(const QString &uri)
         c.setShape(Qt::WaitCursor);
         this->setCursor(c);
         m_tab->setCursor(c);
+        m_side_bar->setCursor(c);
     });
 
     connect(this, &MainWindow::locationChangeEnd, this, [=](){
@@ -651,6 +652,7 @@ void MainWindow::initUI(const QString &uri)
         c.setShape(Qt::ArrowCursor);
         this->setCursor(c);
         m_tab->setCursor(c);
+        m_side_bar->setCursor(c);
         updateHeaderBar();
     });
 

--- a/src/windows/main-window.cpp
+++ b/src/windows/main-window.cpp
@@ -47,6 +47,7 @@
 #include "file-label-box.h"
 
 #include "directory-view-menu.h"
+#include "main-window-factory.h"
 
 #include <QSplitter>
 
@@ -87,6 +88,11 @@ MainWindow::MainWindow(const QString &uri, QWidget *parent) : QMainWindow(parent
 
     //init UI
     initUI(uri);
+}
+
+Peony::FMWindowFactory *MainWindow::getFactory()
+{
+    return MainWindowFactory::getInstance();
 }
 
 Peony::DirectoryViewContainer *MainWindow::getCurrentPage()

--- a/src/windows/main-window.cpp
+++ b/src/windows/main-window.cpp
@@ -46,6 +46,8 @@
 
 #include "file-label-box.h"
 
+#include "directory-view-menu.h"
+
 #include <QSplitter>
 
 #include <QPainter>
@@ -400,6 +402,10 @@ void MainWindow::initUI(const QString &uri)
     connect(m_tab, &TabWidget::activePageLocationChanged, this, &MainWindow::locationChangeEnd);
     connect(m_tab, &TabWidget::activePageViewTypeChanged, this, &MainWindow::updateHeaderBar);
     connect(m_tab, &TabWidget::activePageChanged, this, &MainWindow::updateHeaderBar);
+    connect(m_tab, &TabWidget::menuRequest, this, [=](){
+        Peony::DirectoryViewMenu menu(this);
+        menu.exec(QCursor::pos());
+    });
 }
 
 QRect MainWindow::sideBarRect()

--- a/src/windows/main-window.cpp
+++ b/src/windows/main-window.cpp
@@ -57,6 +57,8 @@
 #include "directory-view-widget.h"
 #include "main-window-factory.h"
 
+#include "peony-application.h"
+
 #include <QSplitter>
 
 #include <QPainter>
@@ -211,13 +213,7 @@ void MainWindow::setShortCuts()
     auto aboutAction = new QAction(this);
     aboutAction->setShortcut(QKeySequence(Qt::CTRL + Qt::Key_F2));
     connect(aboutAction, &QAction::triggered, this, [=](){
-        QMessageBox::about(this,
-                           tr("Peony Qt"),
-                           tr("Authour: \n"
-                              "\tYue Lan <lanyue@kylinos.cn>\n"
-                              "\tMeihong He <hemeihong@kylinos.cn>\n"
-                              "\n"
-                              "Copyright (C): 2019, Tianjin KYLIN Information Technology Co., Ltd."));
+        PeonyApplication::about();
     });
     addAction(aboutAction);
 

--- a/src/windows/main-window.h
+++ b/src/windows/main-window.h
@@ -1,20 +1,20 @@
 /*
- * Peony-Qt's Library
+ * Peony-Qt
  *
  * Copyright (C) 2020, Tianjin KYLIN Information Technology Co., Ltd.
  *
- * This library is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
  *
- * This library is distributed in the hope that it will be useful,
+ * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this library.  If not, see <https://www.gnu.org/licenses/>.
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  *
  * Authors: Yue Lan <lanyue@kylinos.cn>
  *
@@ -24,21 +24,34 @@
 #define MAINWINDOW_H
 
 #include <QMainWindow>
+class MainWindowPrivate;
 class BorderShadowEffect;
+class HeaderBar;
+class DirectoryViewContainter;
+class SideBar;
 
 class MainWindow : public QMainWindow
 {
     Q_OBJECT
 public:
-    explicit MainWindow(QWidget *parent = nullptr);
+    explicit MainWindow(const QString &uri = nullptr, QWidget *parent = nullptr);
+
+    QSize sizeHint() const {return QSize(800, 600);}
 
 Q_SIGNALS:
+    void locationChanged(const QString &uri);
+    void viewLoaded(bool successed = true);
+
+public Q_SLOTS:
+    void syncControlsLocation(const QString &uri);
+    void goToUri(const QString &uri, bool addHistory = false, bool force = false);
 
 protected:
     void resizeEvent(QResizeEvent *e);
     void paintEvent(QPaintEvent *e);
 
     void validBorder();
+    void initUI();
 
 private:
     BorderShadowEffect *m_effect;

--- a/src/windows/main-window.h
+++ b/src/windows/main-window.h
@@ -27,6 +27,8 @@
 class MainWindowPrivate;
 class BorderShadowEffect;
 class HeaderBar;
+class NavigationSideBar;
+class TabWidget;
 class DirectoryViewContainter;
 
 class MainWindow : public QMainWindow
@@ -56,10 +58,14 @@ protected:
     void validBorder();
     void initUI();
 
+    QRect sideBarRect();
+
 private:
     BorderShadowEffect *m_effect;
 
     HeaderBar *m_header_bar;
+    NavigationSideBar *m_side_bar;
+    TabWidget *m_tab;
     bool m_is_draging = false;
 };
 

--- a/src/windows/main-window.h
+++ b/src/windows/main-window.h
@@ -50,11 +50,18 @@ protected:
     void resizeEvent(QResizeEvent *e);
     void paintEvent(QPaintEvent *e);
 
+    void mousePressEvent(QMouseEvent *e);
+    void mouseMoveEvent(QMouseEvent *e);
+    void mouseReleaseEvent(QMouseEvent *e);
+
     void validBorder();
     void initUI();
 
 private:
     BorderShadowEffect *m_effect;
+
+    HeaderBar *m_header_bar;
+    bool m_is_draging = false;
 };
 
 #endif // MAINWINDOW_H

--- a/src/windows/main-window.h
+++ b/src/windows/main-window.h
@@ -1,0 +1,47 @@
+/*
+ * Peony-Qt's Library
+ *
+ * Copyright (C) 2020, Tianjin KYLIN Information Technology Co., Ltd.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this library.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Authors: Yue Lan <lanyue@kylinos.cn>
+ *
+ */
+
+#ifndef MAINWINDOW_H
+#define MAINWINDOW_H
+
+#include <QMainWindow>
+class BorderShadowEffect;
+
+class MainWindow : public QMainWindow
+{
+    Q_OBJECT
+public:
+    explicit MainWindow(QWidget *parent = nullptr);
+
+Q_SIGNALS:
+
+protected:
+    void resizeEvent(QResizeEvent *e);
+    void paintEvent(QPaintEvent *e);
+
+    void validBorder();
+
+private:
+    BorderShadowEffect *m_effect;
+};
+
+#endif // MAINWINDOW_H

--- a/src/windows/main-window.h
+++ b/src/windows/main-window.h
@@ -28,7 +28,6 @@ class MainWindowPrivate;
 class BorderShadowEffect;
 class HeaderBar;
 class DirectoryViewContainter;
-class SideBar;
 
 class MainWindow : public QMainWindow
 {

--- a/src/windows/main-window.h
+++ b/src/windows/main-window.h
@@ -74,6 +74,8 @@ Q_SIGNALS:
     void locationChangeEnd();
 
 public Q_SLOTS:
+    void maximizeOrRestore();
+
     void syncControlsLocation(const QString &uri);
     void updateHeaderBar();
     void goToUri(const QString &uri, bool addHistory = false, bool force = false);
@@ -101,7 +103,7 @@ protected:
     void mouseReleaseEvent(QMouseEvent *e);
 
     void validBorder();
-    void initUI();
+    void initUI(const QString &uri);
 
     QRect sideBarRect();
 

--- a/src/windows/main-window.h
+++ b/src/windows/main-window.h
@@ -104,6 +104,7 @@ public Q_SLOTS:
     void setUseDefaultNameSortOrder(bool use);
     void setSortFolderFirst(bool folderFirst);
     void setShortCuts();
+    void checkSettings();
     //imgrate end, need to complete
 
     void setCurrentSelectionUris(const QStringList &uris);

--- a/src/windows/main-window.h
+++ b/src/windows/main-window.h
@@ -29,6 +29,7 @@ class BorderShadowEffect;
 class HeaderBar;
 class NavigationSideBar;
 class TabWidget;
+class QWidgetResizeHandler;
 
 namespace Peony {
 class DirectoryViewContainer;
@@ -106,6 +107,8 @@ protected:
 
 private:
     BorderShadowEffect *m_effect;
+
+    QWidgetResizeHandler *m_resize_handler;
 
     HeaderBar *m_header_bar;
     NavigationSideBar *m_side_bar;

--- a/src/windows/main-window.h
+++ b/src/windows/main-window.h
@@ -24,6 +24,8 @@
 #define MAINWINDOW_H
 
 #include <QMainWindow>
+#include "FMWindowIface.h"
+
 class MainWindowPrivate;
 class BorderShadowEffect;
 class HeaderBar;
@@ -35,7 +37,7 @@ namespace Peony {
 class DirectoryViewContainer;
 }
 
-class MainWindow : public QMainWindow
+class MainWindow : public QMainWindow, public Peony::FMWindowIface
 {
     Q_OBJECT
 public:

--- a/src/windows/main-window.h
+++ b/src/windows/main-window.h
@@ -32,9 +32,11 @@ class HeaderBar;
 class NavigationSideBar;
 class TabWidget;
 class QWidgetResizeHandler;
+class QStackedWidget;
 
 namespace Peony {
 class DirectoryViewContainer;
+class AdvanceSearchBar;
 }
 
 class MainWindow : public QMainWindow, public Peony::FMWindowIface
@@ -91,6 +93,19 @@ public Q_SLOTS:
     void refresh();
     void forceStopLoading();
 
+    //imigrate from fm-window
+    void advanceSearch();
+    void clearRecord();
+    void searchFilter(QString target_path, QString keyWord, bool search_file_name, bool search_content);
+    void filterUpdate(int type_index=0, int time_index=0, int size_index=0);
+
+    void setShowHidden(bool showHidden);
+    void setShowHidden();
+    void setUseDefaultNameSortOrder(bool use);
+    void setSortFolderFirst(bool folderFirst);
+    void setShortCuts();
+    //imgrate end, need to complete
+
     void setCurrentSelectionUris(const QStringList &uris);
     void setCurrentSortOrder (Qt::SortOrder order);
     void setCurrentSortColumn (int sortColumn);
@@ -108,6 +123,7 @@ protected:
 
     void validBorder();
     void initUI(const QString &uri);
+    void initAdvancePage();
 
     QRect sideBarRect();
 
@@ -118,8 +134,15 @@ private:
 
     HeaderBar *m_header_bar;
     NavigationSideBar *m_side_bar;
+    Peony::AdvanceSearchBar *m_filter_bar;
+    QWidget *m_filter;
+    QStackedWidget *m_side_bar_container;
     TabWidget *m_tab;
+
     bool m_is_draging = false;
+    bool m_show_hidden_file = false;
+    bool m_use_default_name_sort_order = true;
+    bool m_folder_first = true;
 };
 
 #endif // MAINWINDOW_H

--- a/src/windows/main-window.h
+++ b/src/windows/main-window.h
@@ -45,6 +45,8 @@ public:
 
     QSize sizeHint() const {return QSize(800, 600);}
 
+    Peony::FMWindowFactory *getFactory();
+
     Peony::DirectoryViewContainer *getCurrentPage();
 
     const QString getCurrentUri();

--- a/src/windows/main-window.h
+++ b/src/windows/main-window.h
@@ -29,7 +29,10 @@ class BorderShadowEffect;
 class HeaderBar;
 class NavigationSideBar;
 class TabWidget;
-class DirectoryViewContainter;
+
+namespace Peony {
+class DirectoryViewContainer;
+}
 
 class MainWindow : public QMainWindow
 {
@@ -39,13 +42,54 @@ public:
 
     QSize sizeHint() const {return QSize(800, 600);}
 
+    Peony::DirectoryViewContainer *getCurrentPage();
+
+    const QString getCurrentUri();
+    const QStringList getCurrentSelections();
+    const QStringList getCurrentAllFileUris();
+
+    Qt::SortOrder getCurrentSortOrder();
+    int getCurrentSortColumn();
+
 Q_SIGNALS:
+    void windowSelectionChanged();
     void locationChanged(const QString &uri);
     void viewLoaded(bool successed = true);
 
+    /*!
+     * \brief locationChangeStart
+     * \details
+     * This signal is used to tell the window doing a location change.
+     * When a window is excuting a location change, it should not excute another
+     * one util the location change finished.
+     */
+    void locationChangeStart();
+    /*!
+     * \brief endLocationChange
+     * \details
+     * This signal is used to tell the window that a location change finished.
+     * Once a location change finished, we can start a new location change.
+     */
+    void locationChangeEnd();
+
 public Q_SLOTS:
     void syncControlsLocation(const QString &uri);
+    void updateHeaderBar();
     void goToUri(const QString &uri, bool addHistory = false, bool force = false);
+
+    void addNewTabs(const QStringList &uris);
+
+    void beginSwitchView(const QString &viewId);
+
+    void refresh();
+    void forceStopLoading();
+
+    void setCurrentSelectionUris(const QStringList &uris);
+    void setCurrentSortOrder (Qt::SortOrder order);
+    void setCurrentSortColumn (int sortColumn);
+
+    void editUri(const QString &uri);
+    void editUris(const QStringList &uris);
 
 protected:
     void resizeEvent(QResizeEvent *e);

--- a/src/windows/windows.pri
+++ b/src/windows/windows.pri
@@ -1,0 +1,9 @@
+INCLUDEPATH += $$PWD
+
+HEADERS += \
+    $$PWD/main-window.h \
+    $$PWD/x11-window-manager.h
+
+SOURCES += \
+    $$PWD/main-window.cpp \
+    $$PWD/x11-window-manager.cpp

--- a/src/windows/windows.pri
+++ b/src/windows/windows.pri
@@ -1,9 +1,11 @@
 INCLUDEPATH += $$PWD
 
 HEADERS += \
+    $$PWD/main-window-factory.h \
     $$PWD/main-window.h \
     $$PWD/x11-window-manager.h
 
 SOURCES += \
+    $$PWD/main-window-factory.cpp \
     $$PWD/main-window.cpp \
     $$PWD/x11-window-manager.cpp

--- a/src/windows/x11-window-manager.cpp
+++ b/src/windows/x11-window-manager.cpp
@@ -70,7 +70,7 @@ bool X11WindowManager::eventFilter(QObject *watched, QEvent *event)
             m_current_widget = static_cast<QWidget *>(watched);
         }
 
-        qDebug()<<event->type();
+        //qDebug()<<event->type();
 
         break;
     }

--- a/src/windows/x11-window-manager.cpp
+++ b/src/windows/x11-window-manager.cpp
@@ -36,6 +36,16 @@
 #include <QX11Info>
 #include <X11/Xlib.h>
 
+static X11WindowManager *global_instance = nullptr;
+
+X11WindowManager *X11WindowManager::getInstance()
+{
+    if (!global_instance) {
+        global_instance = new X11WindowManager;
+    }
+    return global_instance;
+}
+
 X11WindowManager::X11WindowManager(QObject *parent) : QObject(parent)
 {
 

--- a/src/windows/x11-window-manager.cpp
+++ b/src/windows/x11-window-manager.cpp
@@ -29,6 +29,8 @@
 #include <QStyle>
 #include <QStyleOptionTabBarBase>
 
+#include <QApplication>
+
 #include <QDebug>
 
 #include <QX11Info>

--- a/src/windows/x11-window-manager.cpp
+++ b/src/windows/x11-window-manager.cpp
@@ -1,0 +1,109 @@
+/*
+ * Peony-Qt
+ *
+ * Copyright (C) 2020, Tianjin KYLIN Information Technology Co., Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Authors: Yue Lan <lanyue@kylinos.cn>
+ *
+ */
+
+#include "x11-window-manager.h"
+
+#include <QWidget>
+#include <QMouseEvent>
+
+#include <QTabBar>
+#include <QStyle>
+#include <QStyleOptionTabBarBase>
+
+#include <QDebug>
+
+#include <QX11Info>
+#include <X11/Xlib.h>
+
+X11WindowManager::X11WindowManager(QObject *parent) : QObject(parent)
+{
+
+}
+
+bool X11WindowManager::eventFilter(QObject *watched, QEvent *event)
+{
+    switch (event->type()) {
+    case QEvent::MouseButtonPress: {
+        //Make tabbar blank area dragable and do not effect tablabel.
+        if (qobject_cast<QTabBar *>(watched)) {
+            QMouseEvent *e = static_cast<QMouseEvent *>(event);
+            QTabBar *tabBar = qobject_cast<QTabBar *>(watched);
+            if (tabBar->tabAt(e->pos()) != -1)
+                return false;
+        }
+        QMouseEvent *e = static_cast<QMouseEvent *>(event);
+        if (QObject::eventFilter(watched, event))
+            return true;
+        if (e->button() == Qt::LeftButton) {
+            m_is_draging = true;
+            m_current_widget = static_cast<QWidget *>(watched);
+        }
+
+        qDebug()<<event->type();
+
+        break;
+    }
+    case QEvent::MouseMove: {
+        if (m_is_draging) {
+            Display *display = QX11Info::display();
+            Atom netMoveResize = XInternAtom(display, "_NET_WM_MOVERESIZE", False);
+            XEvent xEvent;
+            const auto pos = QCursor::pos();
+
+            memset(&xEvent, 0, sizeof(XEvent));
+            xEvent.xclient.type = ClientMessage;
+            xEvent.xclient.message_type = netMoveResize;
+            xEvent.xclient.display = display;
+            xEvent.xclient.window = m_current_widget->topLevelWidget()->winId();
+            xEvent.xclient.format = 32;
+            xEvent.xclient.data.l[0] = pos.x();
+            xEvent.xclient.data.l[1] = pos.y();
+            xEvent.xclient.data.l[2] = 8;
+            xEvent.xclient.data.l[3] = Button1;
+            xEvent.xclient.data.l[4] = 0;
+
+            XUngrabPointer(display, CurrentTime);
+            XSendEvent(display, QX11Info::appRootWindow(QX11Info::appScreen()),
+                       False, SubstructureNotifyMask | SubstructureRedirectMask,
+                       &xEvent);
+            XFlush(display);
+
+            m_is_draging = false;
+        }
+        break;
+    }
+    case QEvent::MouseButtonRelease:{
+        m_is_draging = false;
+        m_current_widget = nullptr;
+        break;
+    }
+    default:
+        return false;
+    }
+    return false;
+}
+
+void X11WindowManager::registerWidget(QWidget *widget)
+{
+    widget->removeEventFilter(this);
+    widget->installEventFilter(this);
+}

--- a/src/windows/x11-window-manager.cpp
+++ b/src/windows/x11-window-manager.cpp
@@ -87,8 +87,8 @@ bool X11WindowManager::eventFilter(QObject *watched, QEvent *event)
             xEvent.xclient.display = display;
             xEvent.xclient.window = m_current_widget->topLevelWidget()->winId();
             xEvent.xclient.format = 32;
-            xEvent.xclient.data.l[0] = pos.x();
-            xEvent.xclient.data.l[1] = pos.y();
+            xEvent.xclient.data.l[0] = pos.x() * qApp->devicePixelRatio();
+            xEvent.xclient.data.l[1] = pos.y() * qApp->devicePixelRatio();
             xEvent.xclient.data.l[2] = 8;
             xEvent.xclient.data.l[3] = Button1;
             xEvent.xclient.data.l[4] = 0;

--- a/src/windows/x11-window-manager.h
+++ b/src/windows/x11-window-manager.h
@@ -29,13 +29,15 @@ class X11WindowManager : public QObject
 {
     Q_OBJECT
 public:
-    explicit X11WindowManager(QObject *parent = nullptr);
+    static X11WindowManager *getInstance();
 
     bool eventFilter(QObject *watched, QEvent *event) override;
 
     void registerWidget(QWidget *widget);
 
 private:
+    explicit X11WindowManager(QObject *parent = nullptr);
+
     bool m_is_draging = false;
     QWidget *m_current_widget = nullptr;
 };

--- a/src/windows/x11-window-manager.h
+++ b/src/windows/x11-window-manager.h
@@ -20,47 +20,24 @@
  *
  */
 
-#ifndef HEADERBAR_H
-#define HEADERBAR_H
+#ifndef X11WINDOWMANAGER_H
+#define X11WINDOWMANAGER_H
 
-#include <QToolBar>
-#include <QToolButton>
-#include <QPushButton>
+#include <QObject>
 
-class MainWindow;
-
-class HeaderBar : public QToolBar
+class X11WindowManager : public QObject
 {
-    friend class MainWindow;
     Q_OBJECT
-private:
-    explicit HeaderBar(MainWindow *parent = nullptr);
+public:
+    explicit X11WindowManager(QObject *parent = nullptr);
 
-Q_SIGNALS:
-    void updateLocationRequest(const QString &uri);
+    bool eventFilter(QObject *watched, QEvent *event) override;
 
-private Q_SLOTS:
-    void setLocation(const QString &uri);
+    void registerWidget(QWidget *widget);
 
 private:
-    const QString m_uri;
-    MainWindow *m_window;
+    bool m_is_draging = false;
+    QWidget *m_current_widget = nullptr;
 };
 
-class HeaderBarToolButton : public QToolButton
-{
-    friend class HeaderBar;
-    friend class MainWindow;
-    Q_OBJECT;
-    explicit HeaderBarToolButton(QWidget *parent = nullptr);
-};
-
-class HeadBarPushButton : public QPushButton
-{
-    friend class HeaderBar;
-    friend class MainWindow;
-    Q_OBJECT
-    explicit HeadBarPushButton(QWidget *parent = nullptr);
-};
-
-#endif // HEADERBAR_H
+#endif // X11WINDOWMANAGER_H

--- a/translations/libpeony-qt/libpeony-qt_zh_CN.ts
+++ b/translations/libpeony-qt/libpeony-qt_zh_CN.ts
@@ -35,6 +35,61 @@
     </message>
 </context>
 <context>
+    <name>FileLabelModel</name>
+    <message>
+        <location filename="../../libpeony-qt/model/file-label-model.cpp" line="38"/>
+        <source>Red</source>
+        <translation>红色</translation>
+    </message>
+    <message>
+        <location filename="../../libpeony-qt/model/file-label-model.cpp" line="39"/>
+        <source>Orange</source>
+        <translation>橙色</translation>
+    </message>
+    <message>
+        <location filename="../../libpeony-qt/model/file-label-model.cpp" line="40"/>
+        <source>Yellow</source>
+        <translation>黄色</translation>
+    </message>
+    <message>
+        <location filename="../../libpeony-qt/model/file-label-model.cpp" line="41"/>
+        <source>Green</source>
+        <translation>绿色</translation>
+    </message>
+    <message>
+        <location filename="../../libpeony-qt/model/file-label-model.cpp" line="42"/>
+        <source>Blue</source>
+        <translation>蓝色</translation>
+    </message>
+    <message>
+        <location filename="../../libpeony-qt/model/file-label-model.cpp" line="43"/>
+        <source>Purple</source>
+        <translation>紫色</translation>
+    </message>
+    <message>
+        <location filename="../../libpeony-qt/model/file-label-model.cpp" line="44"/>
+        <source>Gray</source>
+        <translation>灰色</translation>
+    </message>
+    <message>
+        <location filename="../../libpeony-qt/model/file-label-model.cpp" line="45"/>
+        <source>Transparent</source>
+        <translation>透明</translation>
+    </message>
+    <message>
+        <location filename="../../libpeony-qt/model/file-label-model.cpp" line="111"/>
+        <location filename="../../libpeony-qt/model/file-label-model.cpp" line="333"/>
+        <source>Error</source>
+        <translation>错误</translation>
+    </message>
+    <message>
+        <location filename="../../libpeony-qt/model/file-label-model.cpp" line="111"/>
+        <location filename="../../libpeony-qt/model/file-label-model.cpp" line="333"/>
+        <source>Label or color is duplicated.</source>
+        <translation>标签或者颜色重复</translation>
+    </message>
+</context>
+<context>
     <name>Peony::AdvanceSearchBar</name>
     <message>
         <location filename="../../libpeony-qt/controls/tool-bar/advance-search-bar.cpp" line="55"/>
@@ -358,17 +413,17 @@
 <context>
     <name>Peony::CreateLinkInternalPlugin</name>
     <message>
-        <location filename="../../libpeony-qt/controls/menu/menu-plugin-manager.cpp" line="95"/>
+        <location filename="../../libpeony-qt/controls/menu/menu-plugin-manager.cpp" line="100"/>
         <source>Create Link to Desktop</source>
         <translation>链接到桌面</translation>
     </message>
     <message>
-        <location filename="../../libpeony-qt/controls/menu/menu-plugin-manager.cpp" line="110"/>
+        <location filename="../../libpeony-qt/controls/menu/menu-plugin-manager.cpp" line="115"/>
         <source>Create Link to...</source>
         <translation>链接到...</translation>
     </message>
     <message>
-        <location filename="../../libpeony-qt/controls/menu/menu-plugin-manager.cpp" line="113"/>
+        <location filename="../../libpeony-qt/controls/menu/menu-plugin-manager.cpp" line="118"/>
         <source>Choose a Directory to Create Link</source>
         <translation>选择创建链接的目录</translation>
     </message>
@@ -475,192 +530,192 @@
         <translation>在新窗口中打开(&amp;N)</translation>
     </message>
     <message>
-        <location filename="../../libpeony-qt/controls/menu/directory-view-menu/directory-view-menu.cpp" line="159"/>
+        <location filename="../../libpeony-qt/controls/menu/directory-view-menu/directory-view-menu.cpp" line="161"/>
         <source>Open in New &amp;Tab</source>
         <translation>在新标签页中打开(&amp;T)</translation>
     </message>
     <message>
-        <location filename="../../libpeony-qt/controls/menu/directory-view-menu/directory-view-menu.cpp" line="174"/>
-        <location filename="../../libpeony-qt/controls/menu/directory-view-menu/directory-view-menu.cpp" line="194"/>
+        <location filename="../../libpeony-qt/controls/menu/directory-view-menu/directory-view-menu.cpp" line="176"/>
+        <location filename="../../libpeony-qt/controls/menu/directory-view-menu/directory-view-menu.cpp" line="198"/>
         <source>&amp;Open &quot;%1&quot;</source>
         <translation>打开“%1”(&amp;O)</translation>
     </message>
     <message>
-        <location filename="../../libpeony-qt/controls/menu/directory-view-menu/directory-view-menu.cpp" line="180"/>
+        <location filename="../../libpeony-qt/controls/menu/directory-view-menu/directory-view-menu.cpp" line="182"/>
         <source>Open &quot;%1&quot; in &amp;New Window</source>
         <translation>在新窗口中打开“%1”(&amp;N)</translation>
     </message>
     <message>
-        <location filename="../../libpeony-qt/controls/menu/directory-view-menu/directory-view-menu.cpp" line="187"/>
+        <location filename="../../libpeony-qt/controls/menu/directory-view-menu/directory-view-menu.cpp" line="191"/>
         <source>Open &quot;%1&quot; in New &amp;Tab</source>
         <translation>在新标签页中打开“%1”(&amp;T)</translation>
     </message>
     <message>
-        <location filename="../../libpeony-qt/controls/menu/directory-view-menu/directory-view-menu.cpp" line="199"/>
+        <location filename="../../libpeony-qt/controls/menu/directory-view-menu/directory-view-menu.cpp" line="203"/>
         <source>Open &quot;%1&quot; with...</source>
         <translation>选用其它应用打开“%1”...</translation>
     </message>
     <message>
-        <location filename="../../libpeony-qt/controls/menu/directory-view-menu/directory-view-menu.cpp" line="213"/>
+        <location filename="../../libpeony-qt/controls/menu/directory-view-menu/directory-view-menu.cpp" line="217"/>
         <source>&amp;More applications...</source>
         <translation>更多应用...(&amp;M)</translation>
     </message>
     <message>
-        <location filename="../../libpeony-qt/controls/menu/directory-view-menu/directory-view-menu.cpp" line="219"/>
+        <location filename="../../libpeony-qt/controls/menu/directory-view-menu/directory-view-menu.cpp" line="223"/>
         <source>&amp;Open</source>
         <translation>打开(&amp;O)</translation>
     </message>
     <message>
-        <location filename="../../libpeony-qt/controls/menu/directory-view-menu/directory-view-menu.cpp" line="227"/>
+        <location filename="../../libpeony-qt/controls/menu/directory-view-menu/directory-view-menu.cpp" line="231"/>
         <source>&amp;Open %1 selected files</source>
         <translation>打开%1个选中文件(&amp;O)</translation>
     </message>
     <message>
-        <location filename="../../libpeony-qt/controls/menu/directory-view-menu/directory-view-menu.cpp" line="258"/>
+        <location filename="../../libpeony-qt/controls/menu/directory-view-menu/directory-view-menu.cpp" line="262"/>
         <source>&amp;New...</source>
         <translation>新建...(&amp;N)</translation>
     </message>
     <message>
-        <location filename="../../libpeony-qt/controls/menu/directory-view-menu/directory-view-menu.cpp" line="284"/>
+        <location filename="../../libpeony-qt/controls/menu/directory-view-menu/directory-view-menu.cpp" line="288"/>
         <source>Empty &amp;File</source>
         <translation>空文件(&amp;E)</translation>
     </message>
     <message>
-        <location filename="../../libpeony-qt/controls/menu/directory-view-menu/directory-view-menu.cpp" line="294"/>
+        <location filename="../../libpeony-qt/controls/menu/directory-view-menu/directory-view-menu.cpp" line="298"/>
         <source>&amp;Folder</source>
         <translation>文件夹(&amp;F)</translation>
     </message>
     <message>
-        <location filename="../../libpeony-qt/controls/menu/directory-view-menu/directory-view-menu.cpp" line="298"/>
+        <location filename="../../libpeony-qt/controls/menu/directory-view-menu/directory-view-menu.cpp" line="302"/>
         <source>New Folder</source>
         <translation>新建文件夹</translation>
     </message>
     <message>
-        <location filename="../../libpeony-qt/controls/menu/directory-view-menu/directory-view-menu.cpp" line="323"/>
+        <location filename="../../libpeony-qt/controls/menu/directory-view-menu/directory-view-menu.cpp" line="327"/>
         <source>View Type...</source>
         <translation>视图类型...</translation>
     </message>
     <message>
-        <location filename="../../libpeony-qt/controls/menu/directory-view-menu/directory-view-menu.cpp" line="341"/>
+        <location filename="../../libpeony-qt/controls/menu/directory-view-menu/directory-view-menu.cpp" line="345"/>
         <source>Sort By...</source>
         <translation>排序类型...</translation>
     </message>
     <message>
-        <location filename="../../libpeony-qt/controls/menu/directory-view-menu/directory-view-menu.cpp" line="346"/>
+        <location filename="../../libpeony-qt/controls/menu/directory-view-menu/directory-view-menu.cpp" line="350"/>
         <source>Name</source>
         <translation>文件名称</translation>
     </message>
     <message>
-        <location filename="../../libpeony-qt/controls/menu/directory-view-menu/directory-view-menu.cpp" line="347"/>
+        <location filename="../../libpeony-qt/controls/menu/directory-view-menu/directory-view-menu.cpp" line="351"/>
         <source>File Type</source>
         <translation>文件类型</translation>
     </message>
     <message>
-        <location filename="../../libpeony-qt/controls/menu/directory-view-menu/directory-view-menu.cpp" line="348"/>
+        <location filename="../../libpeony-qt/controls/menu/directory-view-menu/directory-view-menu.cpp" line="352"/>
         <source>File Size</source>
         <translation>文件大小</translation>
     </message>
     <message>
-        <location filename="../../libpeony-qt/controls/menu/directory-view-menu/directory-view-menu.cpp" line="349"/>
+        <location filename="../../libpeony-qt/controls/menu/directory-view-menu/directory-view-menu.cpp" line="353"/>
         <source>Modified Date</source>
         <translation>修改日期</translation>
     </message>
     <message>
-        <location filename="../../libpeony-qt/controls/menu/directory-view-menu/directory-view-menu.cpp" line="365"/>
+        <location filename="../../libpeony-qt/controls/menu/directory-view-menu/directory-view-menu.cpp" line="369"/>
         <source>Sort Order...</source>
         <translation>排序顺序...</translation>
     </message>
     <message>
-        <location filename="../../libpeony-qt/controls/menu/directory-view-menu/directory-view-menu.cpp" line="369"/>
+        <location filename="../../libpeony-qt/controls/menu/directory-view-menu/directory-view-menu.cpp" line="373"/>
         <source>Ascending Order</source>
         <translation>升序</translation>
     </message>
     <message>
-        <location filename="../../libpeony-qt/controls/menu/directory-view-menu/directory-view-menu.cpp" line="370"/>
+        <location filename="../../libpeony-qt/controls/menu/directory-view-menu/directory-view-menu.cpp" line="374"/>
         <source>Descending Order</source>
         <translation>降序</translation>
     </message>
     <message>
-        <location filename="../../libpeony-qt/controls/menu/directory-view-menu/directory-view-menu.cpp" line="383"/>
+        <location filename="../../libpeony-qt/controls/menu/directory-view-menu/directory-view-menu.cpp" line="387"/>
         <source>Sort Preferences...</source>
         <translation>排序偏好...</translation>
     </message>
     <message>
-        <location filename="../../libpeony-qt/controls/menu/directory-view-menu/directory-view-menu.cpp" line="387"/>
+        <location filename="../../libpeony-qt/controls/menu/directory-view-menu/directory-view-menu.cpp" line="391"/>
         <source>Folder First</source>
         <translation>文件夹优先</translation>
     </message>
     <message>
-        <location filename="../../libpeony-qt/controls/menu/directory-view-menu/directory-view-menu.cpp" line="395"/>
+        <location filename="../../libpeony-qt/controls/menu/directory-view-menu/directory-view-menu.cpp" line="399"/>
         <source>Chinese First</source>
         <translation>中文优先</translation>
     </message>
     <message>
-        <location filename="../../libpeony-qt/controls/menu/directory-view-menu/directory-view-menu.cpp" line="403"/>
+        <location filename="../../libpeony-qt/controls/menu/directory-view-menu/directory-view-menu.cpp" line="407"/>
         <source>Show Hidden</source>
         <translation>显示隐藏文件</translation>
     </message>
     <message>
-        <location filename="../../libpeony-qt/controls/menu/directory-view-menu/directory-view-menu.cpp" line="422"/>
+        <location filename="../../libpeony-qt/controls/menu/directory-view-menu/directory-view-menu.cpp" line="426"/>
         <source>&amp;Copy</source>
         <translation>复制(&amp;C)</translation>
     </message>
     <message>
-        <location filename="../../libpeony-qt/controls/menu/directory-view-menu/directory-view-menu.cpp" line="426"/>
+        <location filename="../../libpeony-qt/controls/menu/directory-view-menu/directory-view-menu.cpp" line="430"/>
         <source>Cu&amp;t</source>
         <translation>剪切(&amp;T)</translation>
     </message>
     <message>
-        <location filename="../../libpeony-qt/controls/menu/directory-view-menu/directory-view-menu.cpp" line="430"/>
-        <location filename="../../libpeony-qt/controls/menu/directory-view-menu/directory-view-menu.cpp" line="542"/>
+        <location filename="../../libpeony-qt/controls/menu/directory-view-menu/directory-view-menu.cpp" line="434"/>
+        <location filename="../../libpeony-qt/controls/menu/directory-view-menu/directory-view-menu.cpp" line="546"/>
         <source>&amp;Delete</source>
         <translation>删除(&amp;D)</translation>
     </message>
     <message>
-        <location filename="../../libpeony-qt/controls/menu/directory-view-menu/directory-view-menu.cpp" line="435"/>
+        <location filename="../../libpeony-qt/controls/menu/directory-view-menu/directory-view-menu.cpp" line="439"/>
         <source>&amp;Rename</source>
         <translation>重命名(&amp;R)</translation>
     </message>
     <message>
-        <location filename="../../libpeony-qt/controls/menu/directory-view-menu/directory-view-menu.cpp" line="441"/>
+        <location filename="../../libpeony-qt/controls/menu/directory-view-menu/directory-view-menu.cpp" line="445"/>
         <source>&amp;Paste</source>
         <translation>粘贴(&amp;P)</translation>
     </message>
     <message>
-        <location filename="../../libpeony-qt/controls/menu/directory-view-menu/directory-view-menu.cpp" line="447"/>
+        <location filename="../../libpeony-qt/controls/menu/directory-view-menu/directory-view-menu.cpp" line="451"/>
         <source>&amp;Refresh</source>
         <translation>刷新(&amp;R)</translation>
     </message>
     <message>
-        <location filename="../../libpeony-qt/controls/menu/directory-view-menu/directory-view-menu.cpp" line="462"/>
-        <location filename="../../libpeony-qt/controls/menu/directory-view-menu/directory-view-menu.cpp" line="478"/>
+        <location filename="../../libpeony-qt/controls/menu/directory-view-menu/directory-view-menu.cpp" line="466"/>
+        <location filename="../../libpeony-qt/controls/menu/directory-view-menu/directory-view-menu.cpp" line="482"/>
         <source>&amp;Properties</source>
         <translation>属性(&amp;P)</translation>
     </message>
     <message>
-        <location filename="../../libpeony-qt/controls/menu/directory-view-menu/directory-view-menu.cpp" line="522"/>
+        <location filename="../../libpeony-qt/controls/menu/directory-view-menu/directory-view-menu.cpp" line="526"/>
         <source>&amp;Clean the Trash</source>
         <translation>清空回收站(&amp;C)</translation>
     </message>
     <message>
-        <location filename="../../libpeony-qt/controls/menu/directory-view-menu/directory-view-menu.cpp" line="525"/>
-        <location filename="../../libpeony-qt/controls/menu/directory-view-menu/directory-view-menu.cpp" line="544"/>
+        <location filename="../../libpeony-qt/controls/menu/directory-view-menu/directory-view-menu.cpp" line="529"/>
+        <location filename="../../libpeony-qt/controls/menu/directory-view-menu/directory-view-menu.cpp" line="548"/>
         <source>Delete Permanently</source>
         <translation>永久删除</translation>
     </message>
     <message>
-        <location filename="../../libpeony-qt/controls/menu/directory-view-menu/directory-view-menu.cpp" line="525"/>
-        <location filename="../../libpeony-qt/controls/menu/directory-view-menu/directory-view-menu.cpp" line="544"/>
+        <location filename="../../libpeony-qt/controls/menu/directory-view-menu/directory-view-menu.cpp" line="529"/>
+        <location filename="../../libpeony-qt/controls/menu/directory-view-menu/directory-view-menu.cpp" line="548"/>
         <source>Are you sure that you want to delete these files? Once you start a deletion, the files deleting will never be restored again.</source>
         <translation>确定永久删除这些文件？一旦确定，这些文件将无法被恢复。</translation>
     </message>
     <message>
-        <location filename="../../libpeony-qt/controls/menu/directory-view-menu/directory-view-menu.cpp" line="534"/>
+        <location filename="../../libpeony-qt/controls/menu/directory-view-menu/directory-view-menu.cpp" line="538"/>
         <source>&amp;Restore</source>
         <translation>还原(&amp;R)</translation>
     </message>
     <message>
-        <location filename="../../libpeony-qt/controls/menu/directory-view-menu/directory-view-menu.cpp" line="564"/>
+        <location filename="../../libpeony-qt/controls/menu/directory-view-menu/directory-view-menu.cpp" line="568"/>
         <source>Open Parent Folder in New Window</source>
         <translation>在新窗口中打开文件所在目录</translation>
     </message>
@@ -722,8 +777,20 @@
 	Yue Lan &lt;lanyue@kylinos.cn&gt;
 	Meihong He &lt;hemeihong@kylinos.cn&gt;
 
-Copyright (C): 2019, Tianjin KYLIN Information Technology Co., Ltd.</source>
+Copyright (C): 2019-2020, Tianjin KYLIN Information Technology Co., Ltd.</source>
         <translation>作者:
+	Yue Lan &lt;lanyue@kylinos.cn&gt;
+	Meihong He &lt;hemeihong@kylinos.cn&gt;
+
+版权所有(C): 2019-2020,天津麒麟信息技术有限公司.</translation>
+    </message>
+    <message>
+        <source>Authour: 
+	Yue Lan &lt;lanyue@kylinos.cn&gt;
+	Meihong He &lt;hemeihong@kylinos.cn&gt;
+
+Copyright (C): 2019, Tianjin KYLIN Information Technology Co., Ltd.</source>
+        <translation type="vanished">作者:
 	Yue Lan &lt;lanyue@kylinos.cn&gt;
 	Meihong He &lt;hemeihong@kylinos.cn&gt;
 
@@ -776,6 +843,29 @@ Copyright (C): 2019, Tianjin KYLIN Information Technology Co., Ltd.</source>
         <location filename="../../libpeony-qt/model/file-item-model.cpp" line="287"/>
         <source>Modified Date</source>
         <translation>修改时间</translation>
+    </message>
+</context>
+<context>
+    <name>Peony::FileLabelInternalMenuPlugin</name>
+    <message>
+        <location filename="../../libpeony-qt/controls/menu/menu-plugin-manager.cpp" line="145"/>
+        <source>Add File Label...</source>
+        <translation>添加标记...</translation>
+    </message>
+    <message>
+        <location filename="../../libpeony-qt/controls/menu/menu-plugin-manager.cpp" line="163"/>
+        <source>Delete All Label</source>
+        <translation>删除所有标记</translation>
+    </message>
+    <message>
+        <location filename="../../libpeony-qt/controls/menu/menu-plugin-manager.h" line="78"/>
+        <source>Peony File Labels Menu Extension</source>
+        <translation>文件标记</translation>
+    </message>
+    <message>
+        <location filename="../../libpeony-qt/controls/menu/menu-plugin-manager.h" line="79"/>
+        <source>Tag a File with Menu.</source>
+        <translation>菜单中增加标记功能.</translation>
     </message>
 </context>
 <context>
@@ -1107,17 +1197,17 @@ Copyright (C): 2019, Tianjin KYLIN Information Technology Co., Ltd.</source>
 <context>
     <name>Peony::LocationBar</name>
     <message>
-        <location filename="../../libpeony-qt/controls/navigation-bar/location-bar/location-bar.cpp" line="44"/>
+        <location filename="../../libpeony-qt/controls/navigation-bar/location-bar/location-bar.cpp" line="45"/>
         <source>click the blank area for edit</source>
         <translation>点击空白区域编辑路径</translation>
     </message>
     <message>
-        <location filename="../../libpeony-qt/controls/navigation-bar/location-bar/location-bar.cpp" line="71"/>
+        <location filename="../../libpeony-qt/controls/navigation-bar/location-bar/location-bar.cpp" line="72"/>
         <source>Search &quot;%1&quot; in &quot;%2&quot;</source>
         <translation>在%2中搜索%1</translation>
     </message>
     <message>
-        <location filename="../../libpeony-qt/controls/navigation-bar/location-bar/location-bar.cpp" line="111"/>
+        <location filename="../../libpeony-qt/controls/navigation-bar/location-bar/location-bar.cpp" line="116"/>
         <source>File System</source>
         <translation>文件系统</translation>
     </message>
@@ -1441,7 +1531,7 @@ Copyright (C): 2019, Tianjin KYLIN Information Technology Co., Ltd.</source>
     </message>
     <message>
         <location filename="../../libpeony-qt/controls/tool-bar/tool-bar.cpp" line="186"/>
-        <location filename="../../libpeony-qt/controls/tool-bar/tool-bar.cpp" line="339"/>
+        <location filename="../../libpeony-qt/controls/tool-bar/tool-bar.cpp" line="340"/>
         <source>Copy</source>
         <translation>复制</translation>
     </message>

--- a/translations/peony-qt-desktop/peony-qt-desktop_zh_CN.ts
+++ b/translations/peony-qt-desktop/peony-qt-desktop_zh_CN.ts
@@ -197,9 +197,14 @@
 <context>
     <name>Peony::DesktopWindow</name>
     <message>
-        <location filename="../../peony-qt-desktop/desktop-window.cpp" line="172"/>
+        <location filename="../../peony-qt-desktop/desktop-window.cpp" line="173"/>
         <source>set background</source>
         <translation>设置壁纸</translation>
+    </message>
+    <message>
+        <location filename="../../peony-qt-desktop/desktop-window.cpp" line="522"/>
+        <source>New Folder</source>
+        <translation>新建文件夹</translation>
     </message>
 </context>
 <context>
@@ -211,7 +216,7 @@
     <message>
         <location filename="../../peony-qt-desktop/peony-desktop-application.cpp" line="147"/>
         <source>Close the peony desktop window</source>
-        <translation type="unfinished"></translation>
+        <translation>关闭桌面程序</translation>
     </message>
     <message>
         <location filename="../../peony-qt-desktop/peony-desktop-application.cpp" line="150"/>

--- a/translations/peony-qt/peony-qt_zh_CN.ts
+++ b/translations/peony-qt/peony-qt_zh_CN.ts
@@ -2,28 +2,186 @@
 <!DOCTYPE TS>
 <TS version="2.1" language="zh_CN">
 <context>
+    <name>FileLabelBox</name>
+    <message>
+        <location filename="../../src/control/file-label-box.cpp" line="53"/>
+        <source>Rename</source>
+        <translation>重命名</translation>
+    </message>
+    <message>
+        <location filename="../../src/control/file-label-box.cpp" line="58"/>
+        <source>Edit Color</source>
+        <translation>编辑颜色</translation>
+    </message>
+    <message>
+        <location filename="../../src/control/file-label-box.cpp" line="66"/>
+        <source>Delete</source>
+        <translation>删除标记</translation>
+    </message>
+    <message>
+        <location filename="../../src/control/file-label-box.cpp" line="71"/>
+        <source>Create New Label</source>
+        <translation>创建标记</translation>
+    </message>
+</context>
+<context>
+    <name>HeaderBar</name>
+    <message>
+        <location filename="../../src/control/header-bar.cpp" line="58"/>
+        <source>Create Folder</source>
+        <translation>新建文件夹</translation>
+    </message>
+    <message>
+        <location filename="../../src/control/header-bar.cpp" line="68"/>
+        <source>Open Terminal</source>
+        <translation>打开终端</translation>
+    </message>
+    <message>
+        <location filename="../../src/control/header-bar.cpp" line="81"/>
+        <source>Go Back</source>
+        <translation>后退</translation>
+    </message>
+    <message>
+        <location filename="../../src/control/header-bar.cpp" line="92"/>
+        <source>Go Forward</source>
+        <translation>前进</translation>
+    </message>
+    <message>
+        <location filename="../../src/control/header-bar.cpp" line="109"/>
+        <source>Search</source>
+        <translation>搜索</translation>
+    </message>
+    <message>
+        <location filename="../../src/control/header-bar.cpp" line="119"/>
+        <source>View Type</source>
+        <translation>视图类型</translation>
+    </message>
+    <message>
+        <location filename="../../src/control/header-bar.cpp" line="137"/>
+        <source>Sort Type</source>
+        <translation>排序类型</translation>
+    </message>
+    <message>
+        <location filename="../../src/control/header-bar.cpp" line="163"/>
+        <source>Option</source>
+        <translation>选项</translation>
+    </message>
+    <message>
+        <location filename="../../src/control/header-bar.cpp" line="176"/>
+        <source>Minimize</source>
+        <translation>最小化</translation>
+    </message>
+    <message>
+        <location filename="../../src/control/header-bar.cpp" line="199"/>
+        <source>Close</source>
+        <translation>最大化</translation>
+    </message>
+</context>
+<context>
+    <name>MainWindow</name>
+    <message>
+        <location filename="../../src/windows/main-window.cpp" line="140"/>
+        <source>Ctrl+H</source>
+        <comment>Show|Hidden</comment>
+        <translation></translation>
+    </message>
+    <message>
+        <location filename="../../src/windows/main-window.cpp" line="146"/>
+        <source>Undo</source>
+        <translation></translation>
+    </message>
+    <message>
+        <location filename="../../src/windows/main-window.cpp" line="153"/>
+        <source>Redo</source>
+        <translation></translation>
+    </message>
+    <message>
+        <source>Peony Qt</source>
+        <translation type="vanished">文件管理器</translation>
+    </message>
+    <message>
+        <location filename="../../src/windows/main-window.cpp" line="265"/>
+        <source>New Folder</source>
+        <translation>新建文件夹</translation>
+    </message>
+</context>
+<context>
+    <name>NavigationSideBar</name>
+    <message>
+        <location filename="../../src/control/navigation-side-bar.cpp" line="113"/>
+        <source>All tags...</source>
+        <translation>所有标记...</translation>
+    </message>
+</context>
+<context>
+    <name>OperationMenu</name>
+    <message>
+        <location filename="../../src/control/operation-menu.cpp" line="56"/>
+        <source>Advance Search</source>
+        <translation>高级搜索</translation>
+    </message>
+    <message>
+        <location filename="../../src/control/operation-menu.cpp" line="63"/>
+        <source>Keep Allow</source>
+        <translation>置顶窗口</translation>
+    </message>
+    <message>
+        <location filename="../../src/control/operation-menu.cpp" line="69"/>
+        <source>Show Hidden</source>
+        <translation>显示隐藏文件</translation>
+    </message>
+    <message>
+        <location filename="../../src/control/operation-menu.cpp" line="76"/>
+        <source>Forbid thumbnailing</source>
+        <translation>禁用缩略图</translation>
+    </message>
+    <message>
+        <location filename="../../src/control/operation-menu.cpp" line="84"/>
+        <source>Resident in Backend</source>
+        <translation>常驻后台</translation>
+    </message>
+    <message>
+        <location filename="../../src/control/operation-menu.cpp" line="95"/>
+        <source>Help</source>
+        <translation>帮助</translation>
+    </message>
+    <message>
+        <location filename="../../src/control/operation-menu.cpp" line="99"/>
+        <source>About</source>
+        <translation>关于</translation>
+    </message>
+</context>
+<context>
+    <name>OperationMenuEditWidget</name>
+    <message>
+        <location filename="../../src/control/operation-menu.cpp" line="128"/>
+        <source>Edit</source>
+        <translation>编辑</translation>
+    </message>
+</context>
+<context>
     <name>PeonyApplication</name>
     <message>
         <source>Peony-Qt</source>
         <translation type="vanished">文件管理器</translation>
     </message>
     <message>
-        <location filename="../../src/peony-application.cpp" line="119"/>
+        <location filename="../../src/peony-application.cpp" line="127"/>
         <source>Files or directories to open</source>
         <translation>需要打开的文件或文件夹</translation>
     </message>
     <message>
-        <location filename="../../src/peony-application.cpp" line="119"/>
+        <location filename="../../src/peony-application.cpp" line="127"/>
         <source>[FILE1, FILE2,...]</source>
         <translation>[文件1，文件2...]</translation>
     </message>
     <message>
-        <location filename="../../src/peony-application.cpp" line="144"/>
+        <location filename="../../src/peony-application.cpp" line="152"/>
         <source>Warning</source>
         <translation>警告</translation>
     </message>
     <message>
-        <location filename="../../src/peony-application.cpp" line="144"/>
+        <location filename="../../src/peony-application.cpp" line="152"/>
         <source>Peony-Qt can not get the system&apos;s icon theme. There are 2 reasons might lead to this problem:
 
 1. Peony-Qt might be running as root, that means you have the higher permission and can do some things which normally forbidden. But, you should learn that if you were in a root, the virtual file system will lose some featrue such as you can not use &quot;My Computer&quot;, the theme and icons might also went wrong. So, run peony-qt in a root is not recommended.
@@ -36,24 +194,75 @@
 2.你使用的系统主题不是qt默认支持的主题，并且你没有安装相关的平台插件。如果你正在使用Gtk主题作为系统主题，尝试安装qt5-gtk2-platformtheme以解决此问题。</translation>
     </message>
     <message>
-        <location filename="../../src/peony-application.h" line="53"/>
+        <location filename="../../src/peony-application.cpp" line="545"/>
+        <source>Peony Qt</source>
+        <translation>文件管理器</translation>
+    </message>
+    <message>
+        <location filename="../../src/peony-application.cpp" line="546"/>
+        <source>Authour: 
+	Yue Lan &lt;lanyue@kylinos.cn&gt;
+	Meihong He &lt;hemeihong@kylinos.cn&gt;
+
+Copyright (C): 2019-2020, Tianjin KYLIN Information Technology Co., Ltd.</source>
+        <translation>作者:
+	Yue Lan &lt;lanyue@kylinos.cn&gt;
+	Meihong He &lt;hemeihong@kylinos.cn&gt;
+
+版权所有(C): 2019-2020,天津麒麟信息技术有限公司.</translation>
+    </message>
+    <message>
+        <location filename="../../src/peony-application.h" line="55"/>
         <source>Close all peony-qt windows and quit</source>
         <translation>关闭所有窗口并退出</translation>
     </message>
     <message>
-        <location filename="../../src/peony-application.h" line="54"/>
+        <location filename="../../src/peony-application.h" line="56"/>
         <source>Show items</source>
         <translation>打开文件所在目录并选中它们</translation>
     </message>
     <message>
-        <location filename="../../src/peony-application.h" line="55"/>
+        <location filename="../../src/peony-application.h" line="57"/>
         <source>Show folders</source>
         <translation>显示文件夹下的内容</translation>
     </message>
     <message>
-        <location filename="../../src/peony-application.h" line="56"/>
+        <location filename="../../src/peony-application.h" line="58"/>
         <source>Show properties</source>
         <translation>打开文件属性窗口</translation>
+    </message>
+</context>
+<context>
+    <name>SortTypeMenu</name>
+    <message>
+        <location filename="../../src/control/sort-type-menu.cpp" line="33"/>
+        <source>File Name</source>
+        <translation>文件名称</translation>
+    </message>
+    <message>
+        <location filename="../../src/control/sort-type-menu.cpp" line="37"/>
+        <source>File Size</source>
+        <translation>文件大小</translation>
+    </message>
+    <message>
+        <location filename="../../src/control/sort-type-menu.cpp" line="41"/>
+        <source>File Type</source>
+        <translation>文件类型</translation>
+    </message>
+    <message>
+        <location filename="../../src/control/sort-type-menu.cpp" line="45"/>
+        <source>Modified Data</source>
+        <translation>修改日期</translation>
+    </message>
+    <message>
+        <location filename="../../src/control/sort-type-menu.cpp" line="60"/>
+        <source>Ascending</source>
+        <translation>升序</translation>
+    </message>
+    <message>
+        <location filename="../../src/control/sort-type-menu.cpp" line="64"/>
+        <source>Descending</source>
+        <translation>降序</translation>
     </message>
 </context>
 </TS>


### PR DESCRIPTION
The main reason of these problem(#19,#79,#84) happens is because  when mouseDoubleClickEvent happens, it always trigger mousePressEvent first. It is hard to specify a single click and a double click.
So I add m_clickTimer to specify single click and double click. Only when single click happened then trigger rename slot.