### PR TITLE
fix rename issue. drop old time trigger and use QTimer::remainingTime()

### DIFF
--- a/libpeony-qt/controls/directory-view/delegate/icon-view-index-widget.cpp
+++ b/libpeony-qt/controls/directory-view/delegate/icon-view-index-widget.cpp
@@ -173,11 +173,12 @@ void IconViewIndexWidget::paintEvent(QPaintEvent *e)
 void IconViewIndexWidget::mousePressEvent(QMouseEvent *e)
 {
     if (e->button() == Qt::LeftButton) {
-        if (m_edit_trigger.isActive()) {
-            m_delegate->getView()->setIndexWidget(m_index, nullptr);
-            m_delegate->getView()->edit(m_index);
-            return;
-        }
+//        if (m_edit_trigger.isActive()) {
+//            qDebug()<<"IconViewIndexWidget::mousePressEvent: edit"<<e->type();
+//            m_delegate->getView()->setIndexWidget(m_index, nullptr);
+//            m_delegate->getView()->edit(m_index);
+//            return;
+//        }
     }
     QWidget::mousePressEvent(e);
 }

--- a/libpeony-qt/controls/directory-view/view/icon-view/icon-view.h
+++ b/libpeony-qt/controls/directory-view/view/icon-view/icon-view.h
@@ -116,7 +116,6 @@ protected:
      * \deprecated
      */
     void changeZoomLevel();
-    void resetEditTriggerTimer();
 
     void dragEnterEvent(QDragEnterEvent *e) override;
     void dragMoveEvent(QDragMoveEvent *e) override;
@@ -125,14 +124,22 @@ protected:
     void mousePressEvent(QMouseEvent *e) override;
     void mouseReleaseEvent(QMouseEvent *e) override;
 
+    void mouseDoubleClickEvent(QMouseEvent *event) override;
+
     void paintEvent(QPaintEvent *e) override;
     void resizeEvent(QResizeEvent *e) override;
 
     void wheelEvent(QWheelEvent *e) override;
 
+private Q_SLOTS:
+    void slotRename();
+
 private:
-    QTimer m_edit_trigger_timer;
     QTimer m_repaint_timer;
+
+    bool  m_editValid;
+    QTimer* m_renameTimer;
+
     QModelIndex m_last_index;
 
     DirectoryViewProxyIface *m_proxy = nullptr;

--- a/libpeony-qt/controls/directory-view/view/list-view/list-view.h
+++ b/libpeony-qt/controls/directory-view/view/list-view/list-view.h
@@ -99,13 +99,19 @@ public Q_SLOTS:
 protected:
     void mousePressEvent(QMouseEvent *e) override;
     void mouseReleaseEvent(QMouseEvent *e) override;
-    void resetEditTriggerTimer();
+    void mouseDoubleClickEvent(QMouseEvent *event) override;
 
+    void dragEnterEvent(QDragEnterEvent *e) override;
+
+private Q_SLOTS:
+    void slotRename();
 private:
     FileItemModel *m_model = nullptr;
     FileItemProxyFilterSortModel *m_proxy_model = nullptr;
 
-    QTimer m_edit_trigger_timer;
+    QTimer* m_renameTimer;
+    bool  m_editValid;
+
     QModelIndex m_last_index;
 
     DirectoryViewProxyIface *m_proxy = nullptr;


### PR DESCRIPTION
fix rename issue(#19,#79,#84). Delete old edit timer and click timer, using renamer instead. When a moursePressEvent happened, check m_renameTimer first. If m_renameTimer's remaining Time fit the range [750, 3000], then trigger rename slot.
when a rename request triggered, let another timer in rename slot do a delay for waiting some events performed, such as doubleclick and drag. After check edit if valid, then decide if edit event really happen.