### PR TITLE
fix tip popup position

### DIFF
--- a/libpeony-qt/file-operation/file-operation-progress-wizard.cpp
+++ b/libpeony-qt/file-operation/file-operation-progress-wizard.cpp
@@ -86,8 +86,21 @@ FileOperationProgressWizard::FileOperationProgressWizard(QWidget *parent) : QWiz
     });
 
     m_delayer = new QTimer(this);
+    m_tip_delayer = new QTimer(this);
     m_delayer->setSingleShot(true);
     m_delayer->setInterval(100);
+
+    connect(m_tip_delayer, &QTimer::timeout, [=]() {
+    m_tray_icon->showMessage(tr("File Operation"),
+                                 tr("A file operation is running backend..."),
+    #if (QT_VERSION >= QT_VERSION_CHECK(5, 9, 0))
+                                 QIcon::fromTheme("system-file-manager"),
+    #else
+                                 QSystemTrayIcon::MessageIcon::Information,
+    #endif
+                                 5000);
+    m_tip_delayer->stop();
+    });
 }
 
 FileOperationProgressWizard::~FileOperationProgressWizard()
@@ -111,7 +124,10 @@ void FileOperationProgressWizard::closeEvent(QCloseEvent *e)
 #else
                              QSystemTrayIcon::MessageIcon::Information,
 #endif
-                             5000);
+                             1);
+
+    m_tip_delayer->start(800);
+
     hide();
 }
 

--- a/libpeony-qt/file-operation/file-operation-progress-wizard.h
+++ b/libpeony-qt/file-operation/file-operation-progress-wizard.h
@@ -110,6 +110,7 @@ protected:
 private:
     QSystemTrayIcon *m_tray_icon = nullptr;
     QTimer *m_delayer;
+    QTimer *m_tip_delayer;
 };
 
 class PEONYCORESHARED_EXPORT FileOperationPreparePage : public QWizardPage


### PR DESCRIPTION
bug id: 13999

当大量文件移动过程中，点击文件移动进度指示框的关闭按钮时候，文件移动进度指示框会在系统托盘中最小化显示，同时弹出提醒框。此bug就是提醒框先显示在屏幕最左上角一次，然后才能在正确的位置显示。已修复！