### PR TITLE
fix desktop shortcut cannot be opened in arm

### DIFF
--- a/peony-qt-desktop/desktop-icon-view.cpp
+++ b/peony-qt-desktop/desktop-icon-view.cpp
@@ -448,7 +448,16 @@ void DesktopIconView::initDoubleClick()
                 p.startDetached();
 #else
                 QProcess p;
-                p.startDetached("peony", QStringList()<<uri<<"%U&");
+                QString strq;
+                for (int i = 0;i < uri.length();++i) {
+                    if(uri[i] == ' '){
+                        strq += "%20";
+                    }else{
+                        strq += uri[i];
+                    }
+                }
+
+                p.startDetached("peony", QStringList()<<strq<<"%U&");
 #endif
             } else {
                 FileLaunchManager::openAsync(uri, false, false);


### PR DESCRIPTION
fix  bug14467 ,  shortcut cannot open . because the qt-version is lower than x86 ,  uri contain space case the problem.