### PR TITLE
修改快捷方式的命名

### DIFF
--- a/libpeony-qt/file-operation/file-link-operation.cpp
+++ b/libpeony-qt/file-operation/file-link-operation.cpp
@@ -33,17 +33,12 @@ FileLinkOperation::FileLinkOperation(QString srcUri, QString destDirUri, QObject
 {
     m_src_uri = srcUri;
     QUrl url = srcUri;
-    if (!url.fileName().contains(".")) {
-        m_dest_uri = destDirUri + "/" + url.fileName() + tr(" - Symbolic Link");
-    } else {
-        QString tmp = url.fileName();
-
-        while (tmp.contains(".")) {
-            tmp.chop(1);
-        }
-        auto destFileName = url.fileName().insert(tmp.count(), tr(" - Symbolic Link"));
-
-        m_dest_uri = m_dest_uri = destDirUri + "/" + destFileName;
+    //If it starts with a ".", add it directly to the end
+    if(url.fileName().startsWith('.')){
+        m_dest_uri = destDirUri + "/" + url.fileName() + " - " + tr("Symbolic Link");
+    }else{
+        // Otherwise, add it directly to the front
+        m_dest_uri = destDirUri + "/" + tr("Symbolic Link") + " - " + url.fileName();
     }
 
     QStringList fake_uris;

--- a/translations/libpeony-qt/libpeony-qt_tr.ts
+++ b/translations/libpeony-qt/libpeony-qt_tr.ts
@@ -1181,8 +1181,8 @@ Bağlantı dosyasını silmek istiyor musunuz?</translation>
     <message>
         <location filename="../../libpeony-qt/file-operation/file-link-operation.cpp" line="37"/>
         <location filename="../../libpeony-qt/file-operation/file-link-operation.cpp" line="44"/>
-        <source> - Symbolic Link</source>
-        <translation> - Sembolik Bağlantı</translation>
+        <source>Symbolic Link</source>
+        <translation>Sembolik Bağlantı</translation>
     </message>
 </context>
 <context>
@@ -1289,8 +1289,8 @@ Bağlantı dosyasını silmek istiyor musunuz?</translation>
     <message>
         <location filename="../../libpeony-qt/file-operation/file-operation-manager.h" line="189"/>
         <location filename="../../libpeony-qt/file-operation/file-operation-manager.h" line="192"/>
-        <source> - Symbolic Link</source>
-        <translation> Sembolik Bağ</translation>
+        <source>Symbolic Link</source>
+        <translation>Sembolik Bağ</translation>
     </message>
 </context>
 <context>

--- a/translations/libpeony-qt/libpeony-qt_zh_CN.ts
+++ b/translations/libpeony-qt/libpeony-qt_zh_CN.ts
@@ -1181,8 +1181,8 @@ Do you want to delete the link file?</source>
     <message>
         <location filename="../../libpeony-qt/file-operation/file-link-operation.cpp" line="37"/>
         <location filename="../../libpeony-qt/file-operation/file-link-operation.cpp" line="44"/>
-        <source> - Symbolic Link</source>
-        <translation> - 快捷方式</translation>
+        <source>Symbolic Link</source>
+        <translation>快捷方式</translation>
     </message>
 </context>
 <context>
@@ -1289,8 +1289,8 @@ Do you want to delete the link file?</source>
     <message>
         <location filename="../../libpeony-qt/file-operation/file-operation-manager.h" line="189"/>
         <location filename="../../libpeony-qt/file-operation/file-operation-manager.h" line="192"/>
-        <source> - Symbolic Link</source>
-        <translation> - 快捷方式</translation>
+        <source>Symbolic Link</source>
+        <translation>快捷方式</translation>
     </message>
 </context>
 <context>


### PR DESCRIPTION
修改快捷方式的命名,将快捷方式调至文件前，解决在文件后无法确定位置的问题，同时调整语言文件的内容，将短横线放到代码中，而不在语言文件