### PR TITLE
[FIX]

### DIFF
--- a/libpeony-qt/file-operation/create-template-operation.cpp
+++ b/libpeony-qt/file-operation/create-template-operation.cpp
@@ -152,7 +152,7 @@ retry_create_empty_folder:
                 except.dlgType = ED_WARNING;
                 except.destDirUri = m_dest_dir_uri;
                 except.isCritical = true;
-                except.title = tr("Create file");
+                except.title = tr("Create file error");
                 except.errorCode = err->code;
                 except.errorType = ET_GIO;
                 Q_EMIT errored(except);
@@ -182,7 +182,7 @@ retry_create_template:
                 except.dlgType = ED_WARNING;
                 except.destDirUri = m_dest_dir_uri;
                 except.isCritical = true;
-                except.title = tr("Create file");
+                except.title = tr("Create file error");
                 except.errorCode = err->code;
                 except.errorType = ET_GIO;
                 Q_EMIT errored(except);

--- a/libpeony-qt/file-operation/file-copy-operation.cpp
+++ b/libpeony-qt/file-operation/file-copy-operation.cpp
@@ -186,7 +186,7 @@ fallback_retry:
             except.errorType = ET_GIO;
             except.srcUri = m_current_src_uri;
             except.destDirUri = m_current_dest_dir_uri;
-            except.title = tr("File copy");
+            except.title = tr("File copy error");
             except.errorCode = err->code;
             if (handle_type == Other) {
                 if (G_IO_ERROR_EXISTS == err->code) {
@@ -305,7 +305,7 @@ fallback_retry:
             auto errWrapperPtr = GErrorWrapper::wrapFrom(err);
             int handle_type = prehandle(err);
             except.errorType = ET_GIO;
-            except.title = tr("File copy");
+            except.title = tr("File copy error");
             except.srcUri = m_current_src_uri;
             except.errorCode = err->code;
             except.errorStr = err->message;

--- a/libpeony-qt/file-operation/file-delete-operation.cpp
+++ b/libpeony-qt/file-operation/file-delete-operation.cpp
@@ -69,7 +69,7 @@ void FileDeleteOperation::deleteRecursively(FileNode *node)
             except.errorType = ET_GIO;
             except.dlgType = ED_WARNING;
             except.srcUri = node->uri();
-            except.title = tr("File delete");
+            except.title = tr("File delete error");
             except.errorStr = err->message;
             except.errorCode = err->code;
             Q_EMIT errored(except);
@@ -94,7 +94,7 @@ void FileDeleteOperation::deleteRecursively(FileNode *node)
             except.errorType = ET_GIO;
             except.dlgType = ED_WARNING;
             except.srcUri = node->uri();
-            except.title = tr("File delete");
+            except.title = tr("File delete error");
             except.errorCode = err->code;
             except.errorStr = err->message;
             Q_EMIT errored(except);

--- a/libpeony-qt/file-operation/file-link-operation.cpp
+++ b/libpeony-qt/file-operation/file-link-operation.cpp
@@ -71,7 +71,7 @@ retry:
         except.isCritical = true;
         except.errorStr = err->message;
         except.errorCode = err->code;
-        except.title = tr("Link file");
+        except.title = tr("Link file error");
         except.destDirUri = m_dest_uri;
         auto responseType = Invalid;
         if (G_IO_ERROR_EXISTS == err->code) {

--- a/libpeony-qt/file-operation/file-move-operation.cpp
+++ b/libpeony-qt/file-operation/file-move-operation.cpp
@@ -197,7 +197,7 @@ retry:
             except.srcUri = srcUri;
             except.destDirUri = m_dest_dir_uri;
             except.isCritical = false;
-            except.title = tr("Move file");
+            except.title = tr("Move file error");
             except.errorCode = err->code;
             except.errorType = ET_GIO;
             if (handle_type == Other) {
@@ -320,7 +320,7 @@ retry:
             except.srcUri = srcUri;
             except.errorType = ET_GIO;
             except.errorCode = err->code;
-            except.title = tr("Move file");
+            except.title = tr("Move file error");
             except.destDirUri = m_dest_dir_uri;
             except.isCritical = true;
             if (handled_err) {
@@ -563,7 +563,7 @@ fallback_retry:
             auto errWrapperPtr = GErrorWrapper::wrapFrom(err);
             int handle_type = prehandle(err);
             except.errorType = ET_GIO;
-            except.title = tr("Move file");
+            except.title = tr("Move file error");
             except.errorCode = err->code;
             except.errorStr = err->message;
             except.srcUri = m_current_src_uri;
@@ -689,7 +689,7 @@ fallback_retry:
             except.errorType = ET_GIO;
             except.errorCode = err->code;
             except.errorStr = err->message;
-            except.title = tr("Create file");
+            except.title = tr("Create file error");
             except.srcUri = m_current_src_uri;
             except.destDirUri = m_current_dest_dir_uri;
             if (handle_type == Other) {
@@ -928,7 +928,7 @@ start:
         except.dlgType = ED_WARNING;
         except.srcUri = nullptr;
         except.destDirUri = nullptr;
-        except.title = tr("File delete");
+        except.title = tr("File delete error");
         except.errorCode = G_IO_ERROR_INVAL;
         except.errorStr = tr("Invalid Operation");
         Q_EMIT errored(except);

--- a/libpeony-qt/file-operation/file-operation-error-dialogs.cpp
+++ b/libpeony-qt/file-operation/file-operation-error-dialogs.cpp
@@ -26,6 +26,7 @@
 #include <QPushButton>
 #include <file-info.h>
 #include <file-info-job.h>
+#include <QHBoxLayout>
 
 static QPixmap drawSymbolicColoredPixmap (const QPixmap& source);
 
@@ -318,6 +319,8 @@ void Peony::FileInformationLabel::mouseDoubleClickEvent(QMouseEvent *event)
 {
     Q_EMIT active();
     Q_EMIT choosed();
+
+    Q_UNUSED(event);
 }
 
 Peony::FileOperationErrorHandler *Peony::FileOperationErrorDialogFactory::getDialog(Peony::FileOperationError &errInfo)
@@ -341,8 +344,20 @@ Peony::FileOperationErrorDialogWarning::FileOperationErrorDialogWarning(Peony::F
     m_icon->setGeometry(m_margin_lr, m_pic_top, m_pic_size, m_pic_size);
     m_icon->setPixmap(QIcon::fromTheme("dialog-error").pixmap(m_pic_size, m_pic_size));
 
-    m_text = new QLabel(this);
-    m_text->setGeometry(m_margin + m_margin_lr + m_pic_size, m_text_y, width() - m_margin - m_margin_lr - m_pic_size, m_text_heigth);
+    m_text_scroll = new QScrollArea(this);
+    m_text_scroll->setFrameShape(QFrame::NoFrame);
+    m_text_scroll->setGeometry(m_margin + m_margin_lr + m_pic_size, m_text_y,
+                               width() - m_margin - m_margin_lr * 2 - m_pic_size, m_text_heigth);
+
+    m_text = new QLabel(m_text_scroll);
+
+    m_text->setText("");
+    m_text->setWordWrap(true);
+    m_text->setMinimumWidth(width() - m_margin - m_margin_lr * 2 - m_pic_size);
+
+    m_text_scroll->setWidget(m_text);
+    m_text_scroll->setVerticalScrollBarPolicy(Qt::ScrollBarAsNeeded);
+    m_text_scroll->setHorizontalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
 
     m_ok = new QPushButton(this);
     m_ok->setText(tr("OK"));
@@ -366,7 +381,7 @@ void Peony::FileOperationErrorDialogWarning::handle(Peony::FileOperationError &e
 
     if (nullptr != m_error->errorStr) {
         QString htmlString = QString("<style>"
-                                     "  p{font-size:10px;line-height:60%;}"
+                                     "  p{font-size:10px;line-height:100%;}"
                                      "  .bold{text-align: left;font-size:13px;font-wight:500;}"
                                      "</style>"
                                      "<p class='bold'>%1</p>"
@@ -376,13 +391,15 @@ void Peony::FileOperationErrorDialogWarning::handle(Peony::FileOperationError &e
         m_text->setText(htmlString);
     } else {
         QString htmlString = QString("<style>"
-                                     "  p{font-size:10px;line-height:60%;}"
+                                     "  p{font-size:10px;line-height:100%;}"
                                      "  .bold{text-align: left;font-size:13px;font-wight:500;}"
                                      "</style>"
                                      "<p>%1</p>")
                 .arg(tr("Please make sure the disk is not full or not is write protected, or file is not being used."));
         m_text->setText(htmlString);
     }
+
+    m_text->adjustSize();
 
     exec();
 

--- a/libpeony-qt/file-operation/file-operation-error-dialogs.h
+++ b/libpeony-qt/file-operation/file-operation-error-dialogs.h
@@ -26,6 +26,7 @@
 #include <QDialog>
 #include <QCheckBox>
 #include <QLineEdit>
+#include <QScrollArea>
 #include "file-operation-error-dialog-base.h"
 
 namespace Peony {
@@ -67,8 +68,8 @@ private:
     float m_fix_width = 550;
     float m_fix_height = 188;
 
-    float m_text_y = 65;
-    float m_text_heigth = 44;
+    float m_text_y = 40;
+    float m_text_heigth = 75;
 
     float m_ok_x = 410;
     float m_ok_y = 132;
@@ -77,6 +78,7 @@ private:
 
     QLabel* m_icon = nullptr;
     QLabel* m_text = nullptr;
+    QScrollArea* m_text_scroll = nullptr;
     QPushButton* m_ok = nullptr;
 };
 

--- a/libpeony-qt/file-operation/file-rename-operation.cpp
+++ b/libpeony-qt/file-operation/file-rename-operation.cpp
@@ -190,9 +190,10 @@ fallback_retry:
             except.srcUri = m_uri;
             except.destDirUri = FileUtils::getFileUri(newFile);
             except.isCritical = true;
-            except.title = tr("Rename file");
+            except.title = tr("Rename file error");
             except.errorType = ET_GIO;
             except.errorCode = err->code;
+            except.errorStr = err->message;
             if (G_IO_ERROR_EXISTS == err->code) {
                 except.dlgType = ED_CONFLICT;
                 auto responseType = except.respCode;
@@ -227,7 +228,7 @@ retry:
         except.destDirUri = FileUtils::getFileUri(newFile);
         except.isCritical = true;
         except.errorType = ET_GIO;
-        except.title = tr("Rename file");
+        except.title = tr("Rename file error");
         GError *err = nullptr;
         if (FileUtils::isFileExsit(g_file_get_uri(newFile.get()->get()))) {
             except.dlgType = ED_CONFLICT;
@@ -273,6 +274,13 @@ retry:
                 break;
             }
         }
+
+        char* newName = g_file_get_basename(newFile.get()->get());
+        g_file_set_display_name(file.get()->get(), newName, nullptr, &err);
+        if (nullptr != newName) {
+            g_free(newName);
+        }
+/*
         g_file_move(file.get()->get(),
                     newFile.get()->get(),
                     m_default_copy_flag,
@@ -280,9 +288,11 @@ retry:
                     nullptr,
                     nullptr,
                     &err);
+*/
         if (err) {
             except.errorType = ET_GIO;
             except.errorCode = err->code;
+            except.errorStr = err->message;
             auto responseType = Invalid;
             if (G_IO_ERROR_EXISTS != err->code) {
                 except.dlgType = ED_WARNING;

--- a/libpeony-qt/file-operation/file-trash-operation.cpp
+++ b/libpeony-qt/file-operation/file-trash-operation.cpp
@@ -52,8 +52,9 @@ retry:
             except.srcUri = src;
             except.destDirUri = tr("trash:///");
             except.isCritical = true;
-            except.title = tr("Trash file");
+            except.title = tr("Trash file error");
             except.errorCode = err->code;
+            except.errorStr = err->message;
             except.errorType = ET_GIO;
             if (G_IO_ERROR_EXISTS == err->code) {
                 except.dlgType = ED_CONFLICT;

--- a/libpeony-qt/file-operation/file-untrash-operation.cpp
+++ b/libpeony-qt/file-operation/file-untrash-operation.cpp
@@ -166,7 +166,7 @@ retry:
             except.srcUri = uri;
             except.destDirUri = originUri;
             except.isCritical = false;
-            except.title = tr("Untrash file");
+            except.title = tr("Untrash file error");
             except.errorCode = err->code;
             except.errorType = ET_GIO;
             this->setHasError(true);

--- a/translations/libpeony-qt/libpeony-qt_tr.ts
+++ b/translations/libpeony-qt/libpeony-qt_tr.ts
@@ -576,8 +576,6 @@
     </message>
     <message>
         <location filename="../../libpeony-qt/file-operation/create-template-operation.cpp" line="128"/>
-        <location filename="../../libpeony-qt/file-operation/create-template-operation.cpp" line="155"/>
-        <location filename="../../libpeony-qt/file-operation/create-template-operation.cpp" line="185"/>
         <source>Create file</source>
         <translation type="unfinished">Dosya oluştur</translation>
     </message>
@@ -585,6 +583,12 @@
         <location filename="../../libpeony-qt/file-operation/create-template-operation.cpp" line="137"/>
         <source>NewFolder</source>
         <translation>Yeni Klasör</translation>
+    </message>
+    <message>
+        <location filename="../../libpeony-qt/file-operation/create-template-operation.cpp" line="155"/>
+        <location filename="../../libpeony-qt/file-operation/create-template-operation.cpp" line="185"/>
+        <source>Create file error</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -1012,19 +1016,27 @@ Copyright (C): 2019, Tianjin KYLIN Information Technology Co., Ltd.</translation
 <context>
     <name>Peony::FileCopyOperation</name>
     <message>
+        <source>File copy</source>
+        <translation type="obsolete">Dosya kopyalama</translation>
+    </message>
+    <message>
         <location filename="../../libpeony-qt/file-operation/file-copy-operation.cpp" line="189"/>
         <location filename="../../libpeony-qt/file-operation/file-copy-operation.cpp" line="308"/>
-        <source>File copy</source>
-        <translation type="unfinished">Dosya kopyalama</translation>
+        <source>File copy error</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>Peony::FileDeleteOperation</name>
     <message>
+        <source>File delete</source>
+        <translation type="obsolete">Dosya silme</translation>
+    </message>
+    <message>
         <location filename="../../libpeony-qt/file-operation/file-delete-operation.cpp" line="72"/>
         <location filename="../../libpeony-qt/file-operation/file-delete-operation.cpp" line="97"/>
-        <source>File delete</source>
-        <translation type="unfinished">Dosya silme</translation>
+        <source>File delete error</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -1040,17 +1052,17 @@ Copyright (C): 2019, Tianjin KYLIN Information Technology Co., Ltd.</translation
 <context>
     <name>Peony::FileInformationLabel</name>
     <message>
-        <location filename="../../libpeony-qt/file-operation/file-operation-error-dialogs.cpp" line="304"/>
+        <location filename="../../libpeony-qt/file-operation/file-operation-error-dialogs.cpp" line="305"/>
         <source>File location:</source>
         <translation type="unfinished">Dosya konumu:</translation>
     </message>
     <message>
-        <location filename="../../libpeony-qt/file-operation/file-operation-error-dialogs.cpp" line="305"/>
+        <location filename="../../libpeony-qt/file-operation/file-operation-error-dialogs.cpp" line="306"/>
         <source>File size:</source>
         <translation type="unfinished">Dosya boyutu:</translation>
     </message>
     <message>
-        <location filename="../../libpeony-qt/file-operation/file-operation-error-dialogs.cpp" line="305"/>
+        <location filename="../../libpeony-qt/file-operation/file-operation-error-dialogs.cpp" line="306"/>
         <source>Modify time:</source>
         <translation type="unfinished">Değiştirme zamanı:</translation>
     </message>
@@ -1268,8 +1280,12 @@ Bağlantı dosyasını silmek istiyor musunuz?</translation>
     </message>
     <message>
         <location filename="../../libpeony-qt/file-operation/file-link-operation.cpp" line="74"/>
+        <source>Link file error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Link file</source>
-        <translation type="unfinished">Dosyayı bağla</translation>
+        <translation type="obsolete">Dosyayı bağla</translation>
     </message>
 </context>
 <context>
@@ -1279,16 +1295,24 @@ Bağlantı dosyasını silmek istiyor musunuz?</translation>
         <translation type="vanished">Geçersiz taşıma işlemi, bir dosyanın kendisini taşıyamaz.</translation>
     </message>
     <message>
+        <source>Move file</source>
+        <translation type="obsolete">Dosyayı taşı</translation>
+    </message>
+    <message>
+        <source>Create file</source>
+        <translation type="obsolete">Dosya oluştur</translation>
+    </message>
+    <message>
         <location filename="../../libpeony-qt/file-operation/file-move-operation.cpp" line="200"/>
         <location filename="../../libpeony-qt/file-operation/file-move-operation.cpp" line="323"/>
         <location filename="../../libpeony-qt/file-operation/file-move-operation.cpp" line="566"/>
-        <source>Move file</source>
-        <translation type="unfinished">Dosyayı taşı</translation>
+        <source>Move file error</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../libpeony-qt/file-operation/file-move-operation.cpp" line="692"/>
-        <source>Create file</source>
-        <translation type="unfinished">Dosya oluştur</translation>
+        <source>Create file error</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../libpeony-qt/file-operation/file-move-operation.cpp" line="917"/>
@@ -1297,8 +1321,12 @@ Bağlantı dosyasını silmek istiyor musunuz?</translation>
     </message>
     <message>
         <location filename="../../libpeony-qt/file-operation/file-move-operation.cpp" line="931"/>
+        <source>File delete error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>File delete</source>
-        <translation type="unfinished">Dosya silme</translation>
+        <translation type="obsolete">Dosya silme</translation>
     </message>
     <message>
         <location filename="../../libpeony-qt/file-operation/file-move-operation.cpp" line="933"/>
@@ -1391,42 +1419,42 @@ Bağlantı dosyasını silmek istiyor musunuz?</translation>
 <context>
     <name>Peony::FileOperationErrorDialogConflict</name>
     <message>
-        <location filename="../../libpeony-qt/file-operation/file-operation-error-dialogs.cpp" line="42"/>
+        <location filename="../../libpeony-qt/file-operation/file-operation-error-dialogs.cpp" line="43"/>
         <source>This location already contains a file with the same name.</source>
         <translation type="unfinished">Bu konum zaten aynı ada sahip bir dosya içeriyor.</translation>
     </message>
     <message>
-        <location filename="../../libpeony-qt/file-operation/file-operation-error-dialogs.cpp" line="43"/>
+        <location filename="../../libpeony-qt/file-operation/file-operation-error-dialogs.cpp" line="44"/>
         <source>Please select the file to keep</source>
         <translation type="unfinished">Lütfen saklanacak dosyayı seçin</translation>
     </message>
     <message>
-        <location filename="../../libpeony-qt/file-operation/file-operation-error-dialogs.cpp" line="47"/>
+        <location filename="../../libpeony-qt/file-operation/file-operation-error-dialogs.cpp" line="48"/>
         <source>Replace</source>
         <translation type="unfinished">Değiştir</translation>
     </message>
     <message>
-        <location filename="../../libpeony-qt/file-operation/file-operation-error-dialogs.cpp" line="54"/>
+        <location filename="../../libpeony-qt/file-operation/file-operation-error-dialogs.cpp" line="55"/>
         <source>Ignore</source>
         <translation type="unfinished">Görmezden Gel</translation>
     </message>
     <message>
-        <location filename="../../libpeony-qt/file-operation/file-operation-error-dialogs.cpp" line="68"/>
+        <location filename="../../libpeony-qt/file-operation/file-operation-error-dialogs.cpp" line="69"/>
         <source>Then do the same thing in a similar situation</source>
         <translation type="unfinished">Sonra benzer bir durumda aynı şeyi yapın</translation>
     </message>
     <message>
-        <location filename="../../libpeony-qt/file-operation/file-operation-error-dialogs.cpp" line="72"/>
+        <location filename="../../libpeony-qt/file-operation/file-operation-error-dialogs.cpp" line="73"/>
         <source>Backup</source>
         <translation type="unfinished">Yedekle</translation>
     </message>
     <message>
-        <location filename="../../libpeony-qt/file-operation/file-operation-error-dialogs.cpp" line="76"/>
+        <location filename="../../libpeony-qt/file-operation/file-operation-error-dialogs.cpp" line="77"/>
         <source>Cancel</source>
         <translation type="unfinished">İptal</translation>
     </message>
     <message>
-        <location filename="../../libpeony-qt/file-operation/file-operation-error-dialogs.cpp" line="80"/>
+        <location filename="../../libpeony-qt/file-operation/file-operation-error-dialogs.cpp" line="81"/>
         <source>OK</source>
         <translation type="unfinished">Tamam</translation>
     </message>
@@ -1434,13 +1462,13 @@ Bağlantı dosyasını silmek istiyor musunuz?</translation>
 <context>
     <name>Peony::FileOperationErrorDialogWarning</name>
     <message>
-        <location filename="../../libpeony-qt/file-operation/file-operation-error-dialogs.cpp" line="348"/>
+        <location filename="../../libpeony-qt/file-operation/file-operation-error-dialogs.cpp" line="363"/>
         <source>OK</source>
         <translation type="unfinished">Tamam</translation>
     </message>
     <message>
-        <location filename="../../libpeony-qt/file-operation/file-operation-error-dialogs.cpp" line="375"/>
-        <location filename="../../libpeony-qt/file-operation/file-operation-error-dialogs.cpp" line="383"/>
+        <location filename="../../libpeony-qt/file-operation/file-operation-error-dialogs.cpp" line="390"/>
+        <location filename="../../libpeony-qt/file-operation/file-operation-error-dialogs.cpp" line="398"/>
         <source>Please make sure the disk is not full or not is write protected, or file is not being used.</source>
         <translation type="unfinished">Lütfen diskin dolu olmadığından veya yazmaya karşı korumalı olmadığından veya dosyanın kullanılmadığından emin olun.</translation>
     </message>
@@ -1643,27 +1671,27 @@ Bağlantı dosyasını silmek istiyor musunuz?</translation>
 <context>
     <name>Peony::FileRenameDialog</name>
     <message>
-        <location filename="../../libpeony-qt/file-operation/file-operation-error-dialogs.cpp" line="410"/>
+        <location filename="../../libpeony-qt/file-operation/file-operation-error-dialogs.cpp" line="427"/>
         <source>Names automatically add serial Numbers (e.g., 1,2,3...)</source>
         <translation type="unfinished">İsimler otomatik olarak seri Numaralar ekler (ör. 1,2,3 ...)</translation>
     </message>
     <message>
-        <location filename="../../libpeony-qt/file-operation/file-operation-error-dialogs.cpp" line="413"/>
+        <location filename="../../libpeony-qt/file-operation/file-operation-error-dialogs.cpp" line="430"/>
         <source>Cancel</source>
         <translation type="unfinished">İptal</translation>
     </message>
     <message>
-        <location filename="../../libpeony-qt/file-operation/file-operation-error-dialogs.cpp" line="418"/>
+        <location filename="../../libpeony-qt/file-operation/file-operation-error-dialogs.cpp" line="435"/>
         <source>New file name</source>
         <translation type="unfinished">Yeni dosya adı</translation>
     </message>
     <message>
-        <location filename="../../libpeony-qt/file-operation/file-operation-error-dialogs.cpp" line="422"/>
+        <location filename="../../libpeony-qt/file-operation/file-operation-error-dialogs.cpp" line="439"/>
         <source>Please enter the file name</source>
         <translation type="unfinished">Lütfen dosya adını girin</translation>
     </message>
     <message>
-        <location filename="../../libpeony-qt/file-operation/file-operation-error-dialogs.cpp" line="424"/>
+        <location filename="../../libpeony-qt/file-operation/file-operation-error-dialogs.cpp" line="441"/>
         <source>OK</source>
         <translation type="unfinished">Tamam</translation>
     </message>
@@ -1671,10 +1699,14 @@ Bağlantı dosyasını silmek istiyor musunuz?</translation>
 <context>
     <name>Peony::FileRenameOperation</name>
     <message>
-        <location filename="../../libpeony-qt/file-operation/file-rename-operation.cpp" line="193"/>
-        <location filename="../../libpeony-qt/file-operation/file-rename-operation.cpp" line="230"/>
         <source>Rename file</source>
-        <translation type="unfinished">Dosyayı yeniden isimlendir</translation>
+        <translation type="obsolete">Dosyayı yeniden isimlendir</translation>
+    </message>
+    <message>
+        <location filename="../../libpeony-qt/file-operation/file-rename-operation.cpp" line="193"/>
+        <location filename="../../libpeony-qt/file-operation/file-rename-operation.cpp" line="231"/>
+        <source>Rename file error</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -1686,16 +1718,24 @@ Bağlantı dosyasını silmek istiyor musunuz?</translation>
     </message>
     <message>
         <location filename="../../libpeony-qt/file-operation/file-trash-operation.cpp" line="55"/>
+        <source>Trash file error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Trash file</source>
-        <translation type="unfinished">Çöp kutusu dosyası</translation>
+        <translation type="obsolete">Çöp kutusu dosyası</translation>
     </message>
 </context>
 <context>
     <name>Peony::FileUntrashOperation</name>
     <message>
-        <location filename="../../libpeony-qt/file-operation/file-untrash-operation.cpp" line="169"/>
         <source>Untrash file</source>
-        <translation type="unfinished">Dosyayı geri al</translation>
+        <translation type="obsolete">Dosyayı geri al</translation>
+    </message>
+    <message>
+        <location filename="../../libpeony-qt/file-operation/file-untrash-operation.cpp" line="169"/>
+        <source>Untrash file error</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/libpeony-qt/libpeony-qt_zh_CN.ts
+++ b/translations/libpeony-qt/libpeony-qt_zh_CN.ts
@@ -576,8 +576,6 @@
     </message>
     <message>
         <location filename="../../libpeony-qt/file-operation/create-template-operation.cpp" line="128"/>
-        <location filename="../../libpeony-qt/file-operation/create-template-operation.cpp" line="155"/>
-        <location filename="../../libpeony-qt/file-operation/create-template-operation.cpp" line="185"/>
         <source>Create file</source>
         <translation>文件创建</translation>
     </message>
@@ -585,6 +583,12 @@
         <location filename="../../libpeony-qt/file-operation/create-template-operation.cpp" line="137"/>
         <source>NewFolder</source>
         <translation>新建文件夹</translation>
+    </message>
+    <message>
+        <location filename="../../libpeony-qt/file-operation/create-template-operation.cpp" line="155"/>
+        <location filename="../../libpeony-qt/file-operation/create-template-operation.cpp" line="185"/>
+        <source>Create file error</source>
+        <translation>创建文件错误</translation>
     </message>
 </context>
 <context>
@@ -1012,19 +1016,27 @@ Copyright (C): 2019, Tianjin KYLIN Information Technology Co., Ltd.</source>
 <context>
     <name>Peony::FileCopyOperation</name>
     <message>
+        <source>File copy</source>
+        <translation type="vanished">文件复制</translation>
+    </message>
+    <message>
         <location filename="../../libpeony-qt/file-operation/file-copy-operation.cpp" line="189"/>
         <location filename="../../libpeony-qt/file-operation/file-copy-operation.cpp" line="308"/>
-        <source>File copy</source>
-        <translation>文件复制</translation>
+        <source>File copy error</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>Peony::FileDeleteOperation</name>
     <message>
+        <source>File delete</source>
+        <translation type="vanished">文件删除</translation>
+    </message>
+    <message>
         <location filename="../../libpeony-qt/file-operation/file-delete-operation.cpp" line="72"/>
         <location filename="../../libpeony-qt/file-operation/file-delete-operation.cpp" line="97"/>
-        <source>File delete</source>
-        <translation>文件删除</translation>
+        <source>File delete error</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -1040,17 +1052,17 @@ Copyright (C): 2019, Tianjin KYLIN Information Technology Co., Ltd.</source>
 <context>
     <name>Peony::FileInformationLabel</name>
     <message>
-        <location filename="../../libpeony-qt/file-operation/file-operation-error-dialogs.cpp" line="304"/>
+        <location filename="../../libpeony-qt/file-operation/file-operation-error-dialogs.cpp" line="305"/>
         <source>File location:</source>
         <translation>文件位置：</translation>
     </message>
     <message>
-        <location filename="../../libpeony-qt/file-operation/file-operation-error-dialogs.cpp" line="305"/>
+        <location filename="../../libpeony-qt/file-operation/file-operation-error-dialogs.cpp" line="306"/>
         <source>File size:</source>
         <translation>文件大小：</translation>
     </message>
     <message>
-        <location filename="../../libpeony-qt/file-operation/file-operation-error-dialogs.cpp" line="305"/>
+        <location filename="../../libpeony-qt/file-operation/file-operation-error-dialogs.cpp" line="306"/>
         <source>Modify time:</source>
         <translation>修改时间：</translation>
     </message>
@@ -1268,8 +1280,12 @@ Do you want to delete the link file?</source>
     </message>
     <message>
         <location filename="../../libpeony-qt/file-operation/file-link-operation.cpp" line="74"/>
+        <source>Link file error</source>
+        <translation>创建文件链接失败</translation>
+    </message>
+    <message>
         <source>Link file</source>
-        <translation>创建文件链接</translation>
+        <translation type="vanished">创建文件链接</translation>
     </message>
 </context>
 <context>
@@ -1279,16 +1295,24 @@ Do you want to delete the link file?</source>
         <translation type="vanished">非法的移动操作，不能自移动到自身。</translation>
     </message>
     <message>
+        <source>Move file</source>
+        <translation type="vanished">文件移动</translation>
+    </message>
+    <message>
+        <source>Create file</source>
+        <translation type="vanished">文件创建</translation>
+    </message>
+    <message>
         <location filename="../../libpeony-qt/file-operation/file-move-operation.cpp" line="200"/>
         <location filename="../../libpeony-qt/file-operation/file-move-operation.cpp" line="323"/>
         <location filename="../../libpeony-qt/file-operation/file-move-operation.cpp" line="566"/>
-        <source>Move file</source>
-        <translation>文件移动</translation>
+        <source>Move file error</source>
+        <translation>移动文件错误</translation>
     </message>
     <message>
         <location filename="../../libpeony-qt/file-operation/file-move-operation.cpp" line="692"/>
-        <source>Create file</source>
-        <translation>文件创建</translation>
+        <source>Create file error</source>
+        <translation>创建文件错误</translation>
     </message>
     <message>
         <location filename="../../libpeony-qt/file-operation/file-move-operation.cpp" line="917"/>
@@ -1297,8 +1321,12 @@ Do you want to delete the link file?</source>
     </message>
     <message>
         <location filename="../../libpeony-qt/file-operation/file-move-operation.cpp" line="931"/>
+        <source>File delete error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>File delete</source>
-        <translation>文件删除</translation>
+        <translation type="vanished">文件删除</translation>
     </message>
     <message>
         <location filename="../../libpeony-qt/file-operation/file-move-operation.cpp" line="933"/>
@@ -1391,42 +1419,42 @@ Do you want to delete the link file?</source>
 <context>
     <name>Peony::FileOperationErrorDialogConflict</name>
     <message>
-        <location filename="../../libpeony-qt/file-operation/file-operation-error-dialogs.cpp" line="42"/>
+        <location filename="../../libpeony-qt/file-operation/file-operation-error-dialogs.cpp" line="43"/>
         <source>This location already contains a file with the same name.</source>
         <translation>目标文件夹里已经包含有同名文件</translation>
     </message>
     <message>
-        <location filename="../../libpeony-qt/file-operation/file-operation-error-dialogs.cpp" line="43"/>
+        <location filename="../../libpeony-qt/file-operation/file-operation-error-dialogs.cpp" line="44"/>
         <source>Please select the file to keep</source>
         <translation>请选择要保留的文件</translation>
     </message>
     <message>
-        <location filename="../../libpeony-qt/file-operation/file-operation-error-dialogs.cpp" line="47"/>
+        <location filename="../../libpeony-qt/file-operation/file-operation-error-dialogs.cpp" line="48"/>
         <source>Replace</source>
         <translation>替换</translation>
     </message>
     <message>
-        <location filename="../../libpeony-qt/file-operation/file-operation-error-dialogs.cpp" line="54"/>
+        <location filename="../../libpeony-qt/file-operation/file-operation-error-dialogs.cpp" line="55"/>
         <source>Ignore</source>
         <translation>忽略</translation>
     </message>
     <message>
-        <location filename="../../libpeony-qt/file-operation/file-operation-error-dialogs.cpp" line="68"/>
+        <location filename="../../libpeony-qt/file-operation/file-operation-error-dialogs.cpp" line="69"/>
         <source>Then do the same thing in a similar situation</source>
         <translation>之后类似情况执行相同操作</translation>
     </message>
     <message>
-        <location filename="../../libpeony-qt/file-operation/file-operation-error-dialogs.cpp" line="72"/>
+        <location filename="../../libpeony-qt/file-operation/file-operation-error-dialogs.cpp" line="73"/>
         <source>Backup</source>
         <translation>备份</translation>
     </message>
     <message>
-        <location filename="../../libpeony-qt/file-operation/file-operation-error-dialogs.cpp" line="76"/>
+        <location filename="../../libpeony-qt/file-operation/file-operation-error-dialogs.cpp" line="77"/>
         <source>Cancel</source>
         <translation>取消</translation>
     </message>
     <message>
-        <location filename="../../libpeony-qt/file-operation/file-operation-error-dialogs.cpp" line="80"/>
+        <location filename="../../libpeony-qt/file-operation/file-operation-error-dialogs.cpp" line="81"/>
         <source>OK</source>
         <translation>确定</translation>
     </message>
@@ -1434,13 +1462,13 @@ Do you want to delete the link file?</source>
 <context>
     <name>Peony::FileOperationErrorDialogWarning</name>
     <message>
-        <location filename="../../libpeony-qt/file-operation/file-operation-error-dialogs.cpp" line="348"/>
+        <location filename="../../libpeony-qt/file-operation/file-operation-error-dialogs.cpp" line="363"/>
         <source>OK</source>
         <translation>确定</translation>
     </message>
     <message>
-        <location filename="../../libpeony-qt/file-operation/file-operation-error-dialogs.cpp" line="375"/>
-        <location filename="../../libpeony-qt/file-operation/file-operation-error-dialogs.cpp" line="383"/>
+        <location filename="../../libpeony-qt/file-operation/file-operation-error-dialogs.cpp" line="390"/>
+        <location filename="../../libpeony-qt/file-operation/file-operation-error-dialogs.cpp" line="398"/>
         <source>Please make sure the disk is not full or not is write protected, or file is not being used.</source>
         <translation>请确保磁盘未满或未被写保护或未被使用。</translation>
     </message>
@@ -1643,27 +1671,27 @@ Do you want to delete the link file?</source>
 <context>
     <name>Peony::FileRenameDialog</name>
     <message>
-        <location filename="../../libpeony-qt/file-operation/file-operation-error-dialogs.cpp" line="410"/>
+        <location filename="../../libpeony-qt/file-operation/file-operation-error-dialogs.cpp" line="427"/>
         <source>Names automatically add serial Numbers (e.g., 1,2,3...)</source>
         <translation>名称后自动添加序号（如:1,2,3...）</translation>
     </message>
     <message>
-        <location filename="../../libpeony-qt/file-operation/file-operation-error-dialogs.cpp" line="413"/>
+        <location filename="../../libpeony-qt/file-operation/file-operation-error-dialogs.cpp" line="430"/>
         <source>Cancel</source>
         <translation>取消</translation>
     </message>
     <message>
-        <location filename="../../libpeony-qt/file-operation/file-operation-error-dialogs.cpp" line="418"/>
+        <location filename="../../libpeony-qt/file-operation/file-operation-error-dialogs.cpp" line="435"/>
         <source>New file name</source>
         <translation>文件名</translation>
     </message>
     <message>
-        <location filename="../../libpeony-qt/file-operation/file-operation-error-dialogs.cpp" line="422"/>
+        <location filename="../../libpeony-qt/file-operation/file-operation-error-dialogs.cpp" line="439"/>
         <source>Please enter the file name</source>
         <translation>请输入文件名</translation>
     </message>
     <message>
-        <location filename="../../libpeony-qt/file-operation/file-operation-error-dialogs.cpp" line="424"/>
+        <location filename="../../libpeony-qt/file-operation/file-operation-error-dialogs.cpp" line="441"/>
         <source>OK</source>
         <translation>确定</translation>
     </message>
@@ -1671,10 +1699,14 @@ Do you want to delete the link file?</source>
 <context>
     <name>Peony::FileRenameOperation</name>
     <message>
-        <location filename="../../libpeony-qt/file-operation/file-rename-operation.cpp" line="193"/>
-        <location filename="../../libpeony-qt/file-operation/file-rename-operation.cpp" line="230"/>
         <source>Rename file</source>
-        <translation>文件重命名</translation>
+        <translation type="vanished">文件重命名</translation>
+    </message>
+    <message>
+        <location filename="../../libpeony-qt/file-operation/file-rename-operation.cpp" line="193"/>
+        <location filename="../../libpeony-qt/file-operation/file-rename-operation.cpp" line="231"/>
+        <source>Rename file error</source>
+        <translation>重命名文件错误</translation>
     </message>
 </context>
 <context>
@@ -1686,16 +1718,24 @@ Do you want to delete the link file?</source>
     </message>
     <message>
         <location filename="../../libpeony-qt/file-operation/file-trash-operation.cpp" line="55"/>
+        <source>Trash file error</source>
+        <translation>刪除文件到回收站错误</translation>
+    </message>
+    <message>
         <source>Trash file</source>
-        <translation>删除文件到回收站</translation>
+        <translation type="vanished">删除文件到回收站</translation>
     </message>
 </context>
 <context>
     <name>Peony::FileUntrashOperation</name>
     <message>
-        <location filename="../../libpeony-qt/file-operation/file-untrash-operation.cpp" line="169"/>
         <source>Untrash file</source>
-        <translation>撤销删除的文件</translation>
+        <translation type="vanished">撤销删除的文件</translation>
+    </message>
+    <message>
+        <location filename="../../libpeony-qt/file-operation/file-untrash-operation.cpp" line="169"/>
+        <source>Untrash file error</source>
+        <translation>从回收站恢复文件错误</translation>
     </message>
 </context>
 <context>


### PR DESCRIPTION
1. 修复了重命名警告弹框没有gio报错提醒
2. 针对错误信息太多，警告弹框无法显示完全增加了滑动区域显示
3. 按要求将错误弹框的标题由“xxx操作”改为“xxx操作错误”

[Link] 17570