### PR TITLE
  [FIX]

### DIFF
--- a/libpeony-qt/file-operation/file-operation-manager.cpp
+++ b/libpeony-qt/file-operation/file-operation-manager.cpp
@@ -184,7 +184,6 @@ void FileOperationManager::startOperation(FileOperation *operation, bool addToHi
    proc->connect(operation, &FileOperation::operationStartSnyc, proc, &ProgressBar::onStartSync);
    proc->connect(operation, &FileOperation::operationFinished, proc, &ProgressBar::onFinished);
    proc->connect(proc, &ProgressBar::cancelled, operation, &Peony::FileOperation::cancel);
-
    operation->connect(operation, &FileOperation::errored, [=]() {
        operation->setHasError(true);
    });


### PR DESCRIPTION
     1. Cancelling the second operation popover cannot automatically disappear if parallel operations are allowed
     2. Cancel the transmission and then continue the transmission, the pop-up prompts to cancel

  [LINK]
     1. 18107
     2. 18131

修复两个问题，都是在不允许并行操作前提下导致的，根本原因是，不允许并行操作下点击取消，线程在开始执行时候就会退出，并没有发送 finshed 信号，导致我的进度条没有处理。