### PR TITLE
[FIX]  small file transfer flicker

### DIFF
--- a/libpeony-qt/file-info.h
+++ b/libpeony-qt/file-info.h
@@ -159,8 +159,7 @@ public:
     bool isVirtual() {
         return m_is_virtual;
     }
-    bool isValid()
-    {
+    bool isValid() {
         return m_is_valid;
     }
 

--- a/libpeony-qt/file-operation/file-operation-error-dialogs.cpp
+++ b/libpeony-qt/file-operation/file-operation-error-dialogs.cpp
@@ -404,9 +404,32 @@ void Peony::FileOperationErrorDialogWarning::handle(Peony::FileOperationError &e
 
     exec();
 
-    if (G_IO_ERROR_NOT_SUPPORTED == m_error->errorCode || G_IO_ERROR_NO_SPACE == m_error->errorCode) {
+    switch (m_error->errorCode) {
+    case G_IO_ERROR_BUSY:
+    case G_IO_ERROR_CLOSED:
+    case G_IO_ERROR_PENDING:
+    case G_IO_ERROR_NO_SPACE:
+    case G_IO_ERROR_READ_ONLY:
+    case G_IO_ERROR_CANCELLED:
+    case G_IO_ERROR_TIMED_OUT:
+    case G_IO_ERROR_WOULD_BLOCK:
+    case G_IO_ERROR_INVALID_DATA:
+    case G_IO_ERROR_NOT_SUPPORTED:
+    case G_IO_ERROR_NOT_INITIALIZED:
+    case G_IO_ERROR_PERMISSION_DENIED:
+    case G_IO_ERROR_CANT_CREATE_BACKUP:
+    case G_IO_ERROR_TOO_MANY_OPEN_FILES:
         error.respCode = Cancel;
-    } else {
+        break;
+    case G_IO_ERROR_FAILED:
+    case G_IO_ERROR_NOT_FOUND:      //
+    case G_IO_ERROR_IS_DIRECTORY:
+    case G_IO_ERROR_NOT_DIRECTORY:
+    case G_IO_ERROR_FAILED_HANDLED:
+    case G_IO_ERROR_NOT_REGULAR_FILE:
+    case G_IO_ERROR_MESSAGE_TOO_LARGE:
+    case G_IO_ERROR_NOT_SYMBOLIC_LINK:
+    default:
         error.respCode = IgnoreOne;
     }
 }

--- a/libpeony-qt/file-operation/file-operation-progress-bar.cpp
+++ b/libpeony-qt/file-operation/file-operation-progress-bar.cpp
@@ -31,6 +31,8 @@
 
 #include <QUrl>
 #include <QTimer>
+#include <file-info-job.h>
+#include <file-info.h>
 
 QPushButton* btn;
 
@@ -280,7 +282,7 @@ void MainProgressBar::initPrarm()
 {
     m_stopping = false;
     m_current_value = 0.0;
-    m_file_name = tr("starting ...");
+//    m_file_name = tr("starting ...");
 }
 
 void MainProgressBar::setFileIcon(QIcon& icon)
@@ -723,7 +725,21 @@ void ProgressBar::updateProgress(const QString &srcUri, const QString &destUri, 
     QUrl srcUrl = srcUri;
     m_src_uri = srcUrl.toDisplayString();
     QUrl destUrl = destUri;
-    m_dest_uri = destUrl.toDisplayString();
+    QString destPath = destUrl.path();
+
+    Peony::FileInfoJob srcInfoJob (destUri);
+    srcInfoJob.querySync();
+    Peony::FileInfo* srcInfo = srcInfoJob.getInfo().get();
+    if (nullptr != srcInfo && srcInfo->isDir()) {
+        if (destUrl.path().endsWith("/")) {
+            m_dest_uri = destUrl.path() + srcUrl.fileName();
+        } else {
+            m_dest_uri = destUrl.path() + "/" + srcUrl.fileName();
+        }
+    } else {
+        m_dest_uri = destUrl.path();
+    }
+
     if (fIcon != getIcon().name()) {
         setIcon(fIcon);
     }


### PR DESCRIPTION
[LINK] 19771

传输大量小文件本来就会闪烁，但是目标文件传入的可能是文件夹路径，这会导致进度条在 文件夹路径  与  文件路径之间频繁切换，看起来就是闪烁的。