### PR TITLE
[FIX]  Resolved progress bar name flashing during file copying or moving

### DIFF
--- a/libpeony-qt/file-operation/file-copy-operation.cpp
+++ b/libpeony-qt/file-operation/file-copy-operation.cpp
@@ -150,10 +150,9 @@ void FileCopyOperation::progress_callback(goffset current_num_bytes,
     auto currnet = p_this->m_current_offset + current_num_bytes;
     auto total = p_this->m_total_szie;
     auto fileIconName = FileUtils::getFileIconName(p_this->m_current_src_uri, false);
+    auto destFileName = FileUtils::isFileDirectory(p_this->m_current_dest_dir_uri) ? nullptr : p_this->m_current_dest_dir_uri;
     qDebug()<<currnet*1.0/total;
-    Q_EMIT p_this->FileProgressCallback(p_this->m_current_src_uri,
-                                        p_this->m_current_dest_dir_uri,
-                                        fileIconName, currnet, total);
+    Q_EMIT p_this->FileProgressCallback(p_this->m_current_src_uri, destFileName, fileIconName, currnet, total);
 }
 
 void FileCopyOperation::copyRecursively(FileNode *node)

--- a/libpeony-qt/file-operation/file-move-operation.cpp
+++ b/libpeony-qt/file-operation/file-move-operation.cpp
@@ -112,9 +112,9 @@ void FileMoveOperation::progress_callback(goffset current_num_bytes,
     auto currnet = p_this->m_current_offset + current_num_bytes;
     auto total = p_this->m_total_szie;
     auto fileIconName = FileUtils::getFileIconName(p_this->m_current_src_uri, false);
-    Q_EMIT p_this->FileProgressCallback(p_this->m_current_src_uri,
-                                        p_this->m_current_dest_dir_uri,
-                                        fileIconName, currnet, total);
+    auto destFileName = FileUtils::isFileDirectory(p_this->m_current_dest_dir_uri) ? nullptr : p_this->m_current_dest_dir_uri;
+
+    Q_EMIT p_this->FileProgressCallback(p_this->m_current_src_uri, destFileName, fileIconName, currnet, total);
     //format: move srcUri to destDirUri: curent_bytes(count) of total_bytes(count).
 }
 
@@ -549,10 +549,9 @@ fallback_retry:
     if (node->isFolder()) {
         GError *err = nullptr;
         auto fileIconName = FileUtils::getFileIconName(m_current_src_uri, false);
+        auto destFileName = FileUtils::isFileDirectory(m_current_dest_dir_uri) ? nullptr : m_current_dest_dir_uri;
         //NOTE: mkdir doesn't have a progress callback.
-        Q_EMIT FileProgressCallback(m_current_src_uri,
-                                    m_current_dest_dir_uri,
-                                    fileIconName, node->size(), node->size());
+        Q_EMIT FileProgressCallback(m_current_src_uri, destFileName, fileIconName, node->size(), node->size());
         g_file_make_directory(destFile.get()->get(),
                               getCancellable().get()->get(),
                               &err);
@@ -660,11 +659,10 @@ fallback_retry:
         }
 
         fileIconName = FileUtils::getFileIconName(m_current_src_uri, false);
+        destFileName = FileUtils::isFileDirectory(m_current_dest_dir_uri) ? nullptr : m_current_dest_dir_uri;
         //assume that make dir finished anyway
         m_current_offset += node->size();
-        Q_EMIT FileProgressCallback(m_current_src_uri,
-                                    m_current_dest_dir_uri,
-                                    fileIconName, m_current_offset, m_total_szie);
+        Q_EMIT FileProgressCallback(m_current_src_uri, destFileName, fileIconName, m_current_offset, m_total_szie);
         Q_EMIT operationProgressedOne(node->uri(), node->destUri(), node->size());
         for (auto child : *(node->children())) {
             copyRecursively(child);
@@ -809,7 +807,8 @@ fallback_retry:
         }
         m_current_offset += node->size();
         auto fileIconName = FileUtils::getFileIconName(m_current_src_uri, false);
-        Q_EMIT FileProgressCallback(node->uri(), node->destUri(), fileIconName, m_current_offset, m_total_szie);
+        auto destFileName = FileUtils::isFileDirectory(node->destUri()) ? nullptr : node->destUri();
+        Q_EMIT FileProgressCallback(node->uri(), destFileName, fileIconName, m_current_offset, m_total_szie);
         Q_EMIT operationProgressedOne(node->uri(), node->destUri(), node->size());
     }
     destFile.reset();

--- a/libpeony-qt/file-operation/file-operation-progress-bar.cpp
+++ b/libpeony-qt/file-operation/file-operation-progress-bar.cpp
@@ -722,8 +722,11 @@ void ProgressBar::updateProgress(const QString &srcUri, const QString &destUri, 
 
     QUrl srcUrl = srcUri;
     m_src_uri = srcUrl.toDisplayString();
-    QUrl destUrl = destUri;
-    m_dest_uri = destUrl.toDisplayString();
+    if (nullptr != destUri) {
+        QUrl destUrl = destUri;
+        m_dest_uri = destUrl.toDisplayString();
+    }
+
     if (fIcon != getIcon().name()) {
         setIcon(fIcon);
     }


### PR DESCRIPTION
[LINK] 19771

解決进度条文件名闪烁问题，现在进度条只显示传输中的文件，不会再显示传输到的目标文件夹，减少了频繁切换造成的闪烁视觉