### PR TITLE
修改untrash和link操作的undo/redo功能

### DIFF
--- a/libpeony-qt/file-operation/file-operation-manager.cpp
+++ b/libpeony-qt/file-operation/file-operation-manager.cpp
@@ -256,7 +256,7 @@ void FileOperationManager::startUndoOrRedo(std::shared_ptr<FileOperationInfo> in
         break;
     }
     case FileOperationInfo::Link: {
-        op = new FileDeleteOperation(info->m_src_uris);
+        op = new FileLinkOperation(info->m_src_uris.at(0), info->m_dest_dir_uri);
         break;
     }
     case FileOperationInfo::Move: {
@@ -402,4 +402,144 @@ void FileOperationManager::manuallyNotifyDirectoryChanged(FileOperationInfo *inf
             }
         }
     }
+}
+
+//FIXME: get opposite info correcty.
+FileOperationInfo::FileOperationInfo(QStringList srcUris,
+                                     QString destDirUri,
+                                     Type type,
+                                     QObject *parent): QObject(parent)
+{
+    m_src_uris = srcUris;
+    m_dest_dir_uri = destDirUri;
+
+    oppositeInfoConstruct(type);
+}
+
+//FIXME: get opposite info correcty.
+FileOperationInfo::FileOperationInfo(QStringList srcUris,
+                                     QStringList destDirUris,
+                                     Type type,
+                                     QObject *parent): QObject(parent)
+{
+    m_src_uris = srcUris;
+    m_dest_dir_uris = destDirUris;
+
+    oppositeInfoConstruct(type);
+}
+
+void FileOperationInfo::oppositeInfoConstruct(Type type)
+{
+    m_type = type;
+
+    switch (type) {
+        case Move: {
+            m_opposite_type = Move;
+            commonOppositeInfoConstruct();
+            break;
+        }
+        case Trash: {
+            m_opposite_type = Untrash;
+            commonOppositeInfoConstruct();
+            break;
+        }
+        case Untrash: {
+            m_opposite_type = Trash;
+            UntrashOppositeInfoConstruct();
+            break;
+        }
+        case Delete: {
+            m_opposite_type = Other;
+            break;
+        }
+        case Copy: {
+            m_opposite_type = Delete;
+            commonOppositeInfoConstruct();
+            break;
+        }
+        case Rename: {
+            m_opposite_type = Rename;
+            RenameOppositeInfoConstruct();
+            break;
+        }
+        case Link: {
+            m_opposite_type = Delete;
+            LinkOppositeInfoConstruct();
+            break;
+        }
+        case CreateTxt: {
+            m_opposite_type = Delete;
+            commonOppositeInfoConstruct();
+            break;
+        }
+        case CreateFolder: {
+            m_opposite_type = Delete;
+            commonOppositeInfoConstruct();
+            break;
+        }
+        case CreateTemplate: {
+            m_opposite_type = Delete;
+            commonOppositeInfoConstruct();
+            break;
+        }
+        default: {
+            m_opposite_type = Other;
+        }
+    }
+
+    return;
+}
+
+void FileOperationInfo::commonOppositeInfoConstruct()
+{
+    for (auto srcUri : m_src_uris) {
+        auto srcFile = wrapGFile(g_file_new_for_uri(srcUri.toUtf8().constData()));
+        if (m_src_dir_uri.isNull()) {
+            auto srcParent = FileUtils::getFileParent(srcFile);
+            m_src_dir_uri = FileUtils::getFileUri(srcParent);
+        }
+        QString relativePath = FileUtils::getFileBaseName(srcFile);
+        auto destDirFile = wrapGFile(g_file_new_for_uri(m_dest_dir_uri.toUtf8().constData()));
+        auto destFile = FileUtils::resolveRelativePath(destDirFile, relativePath);
+        QString destUri = FileUtils::getFileUri(destFile);
+        m_dest_uris<<destUri;
+    }
+}
+void FileOperationInfo::LinkOppositeInfoConstruct()
+{
+    QUrl url = m_src_uris.first();
+    if (url.fileName().startsWith(".")) {
+        m_dest_uris<<m_dest_dir_uri + "/" + url.fileName() + " - " + tr("Symbolic Link");
+    } else {
+        auto dest_uri = m_dest_dir_uri + "/" + tr("Symbolic Link") + " - " + url.fileName();
+        m_dest_uris<<dest_uri;
+    }
+}
+void FileOperationInfo::RenameOppositeInfoConstruct()
+{
+    //Rename also use the common args format.
+    QString src = m_src_uris.at(0);
+    m_dest_uris<<src;
+    m_src_dir_uri = m_dest_dir_uri;
+}
+void FileOperationInfo::UntrashOppositeInfoConstruct()
+{
+    m_dest_uris = m_dest_dir_uris;
+    m_src_dir_uri = "trash:///";
+    return;
+}
+
+std::shared_ptr<FileOperationInfo> FileOperationInfo::getOppositeInfo(FileOperationInfo *info) {
+
+    auto oppositeInfo = std::make_shared<FileOperationInfo>(info->m_dest_uris, info->m_src_dir_uri, m_opposite_type);
+    QMap<QString, QString> oppsiteMap;
+    for (auto key : m_node_map.keys()) {
+        auto value = m_node_map.value(key);
+        oppsiteMap.insert(value, key);
+    }
+    oppositeInfo->m_node_map = oppsiteMap;
+    oppositeInfo->m_newname = this->m_oldname;
+    oppositeInfo->m_oldname = this->m_newname;
+
+    return oppositeInfo;
 }

--- a/libpeony-qt/file-operation/file-untrash-operation.cpp
+++ b/libpeony-qt/file-operation/file-untrash-operation.cpp
@@ -33,11 +33,11 @@ FileUntrashOperation::FileUntrashOperation(QStringList uris, QObject *parent) : 
     m_uris = uris;
     //FIXME: should i put this into prepare process?
     cacheOriginalUri();
-    QStringList oppositeSrcUris;
+    QStringList destUris;
     for (auto value : m_restore_hash) {
-        oppositeSrcUris<<value;
+        destUris<<value;
     }
-    m_info = std::make_shared<FileOperationInfo>(oppositeSrcUris, "trash:///", FileOperationInfo::Trash);
+    m_info = std::make_shared<FileOperationInfo>(uris, destUris, FileOperationInfo::Untrash);
 }
 
 void FileUntrashOperation::cacheOriginalUri()


### PR DESCRIPTION
      FileOperation: fix undo/redo operation of untrash and link.
      自测结果：
        1、createTemplateOperation不支持 undo/redo的操作，因为该流程不通过Fileoperationmanager执行，设计如此；
        2、filecopy操作支持undo/redo功能；
        3、filedelete操作不支持undo/redo功能，设计如此；
        4、file link支持undo/redo功能，此次修改内容；
        5、filemove操作不出错（文件冲突或者其他错误）时，支持undo/redo操作，而且当出现文件冲突时，move操作变成了copy操作，设计如此；
        6、filerename操作，支持undo/redo功能。
        7、trash测试支持undo/redo操作，但是在回收站中存在多个不同原路径的同名文件的时候，undo/redo操作有问题，有待改善；
        8、untrash操作的undo/redo操作支持（此次修改内容），但是当还原多个文件的时候不支持，在FileOperationUtils做了限制，设计如此。