### PR TITLE
[FIX]  The icon name displays two lines

### DIFF
--- a/peony-qt-desktop/desktop-icon-view-delegate.cpp
+++ b/peony-qt-desktop/desktop-icon-view-delegate.cpp
@@ -214,15 +214,15 @@ QSize DesktopIconViewDelegate::sizeHint(const QStyleOptionViewItem &option, cons
     auto zoomLevel = view->zoomLevel();
     switch (zoomLevel) {
     case DesktopIconView::Small:
-        return QSize(60, 60);
+        return QSize(60, 70);
     case DesktopIconView::Normal:
-        return QSize(90, 90);
+        return QSize(90, 100);
     case DesktopIconView::Large:
-        return QSize(105, 118);
+        return QSize(105, 128);
     case DesktopIconView::Huge:
-        return QSize(120, 140);
+        return QSize(120, 150);
     default:
-        return QSize(90, 90);
+        return QSize(90, 100);
     }
 }
 

--- a/peony-qt-desktop/desktop-icon-view.cpp
+++ b/peony-qt-desktop/desktop-icon-view.cpp
@@ -1074,20 +1074,20 @@ void DesktopIconView::setDefaultZoomLevel(ZoomLevel level)
     switch (level) {
     case Small:
         setIconSize(QSize(24, 24));
-        setGridSize(QSize(64, 64));
+        setGridSize(QSize(64, 74));
         break;
     case Large:
         setIconSize(QSize(64, 64));
-        setGridSize(QSize(115, 135));
+        setGridSize(QSize(115, 145));
         break;
     case Huge:
         setIconSize(QSize(96, 96));
-        setGridSize(QSize(140, 170));
+        setGridSize(QSize(140, 180));
         break;
     default:
         m_zoom_level = Normal;
         setIconSize(QSize(48, 48));
-        setGridSize(QSize(96, 96));
+        setGridSize(QSize(96, 106));
         break;
     }
     clearAllIndexWidgets();


### PR DESCRIPTION
[LINK] http://172.17.66.192/biz/bug-view-19994.html

桌面图标名字显示两行