### PR TITLE
[FIX]  Move a file when the destination file is a folder. The progres…

### DIFF
--- a/libpeony-qt/file-operation/file-copy-operation.cpp
+++ b/libpeony-qt/file-operation/file-copy-operation.cpp
@@ -157,10 +157,12 @@ void FileCopyOperation::progress_callback(goffset current_num_bytes,
     if (total_num_bytes < current_num_bytes)
         return;
 
+    QUrl url(p_this->m_current_src_uri);
     auto currnet = p_this->m_current_offset + current_num_bytes;
     auto total = p_this->m_total_szie;
     auto fileIconName = FileUtils::getFileIconName(p_this->m_current_src_uri, false);
-    auto destFileName = FileUtils::isFileDirectory(p_this->m_current_dest_dir_uri) ? nullptr : p_this->m_current_dest_dir_uri;
+    auto destFileName = FileUtils::isFileDirectory(p_this->m_current_dest_dir_uri) ?
+                p_this->m_current_dest_dir_uri + "/" + url.fileName() : p_this->m_current_dest_dir_uri;
     qDebug()<<currnet*1.0/total;
     Q_EMIT p_this->FileProgressCallback(p_this->m_current_src_uri, destFileName, fileIconName, currnet, total);
 }

--- a/libpeony-qt/file-operation/file-move-operation.cpp
+++ b/libpeony-qt/file-operation/file-move-operation.cpp
@@ -109,10 +109,12 @@ void FileMoveOperation::progress_callback(goffset current_num_bytes,
     if (total_num_bytes < current_num_bytes)
         return;
 
+    QUrl url(p_this->m_current_src_uri);
     auto currnet = p_this->m_current_offset + current_num_bytes;
     auto total = p_this->m_total_szie;
     auto fileIconName = FileUtils::getFileIconName(p_this->m_current_src_uri, false);
-    auto destFileName = FileUtils::isFileDirectory(p_this->m_current_dest_dir_uri) ? nullptr : p_this->m_current_dest_dir_uri;
+    auto destFileName = FileUtils::isFileDirectory(p_this->m_current_dest_dir_uri) ?
+                p_this->m_current_dest_dir_uri + "/" + url.fileName() : p_this->m_current_dest_dir_uri;
 
     Q_EMIT p_this->FileProgressCallback(p_this->m_current_src_uri, destFileName, fileIconName, currnet, total);
     //format: move srcUri to destDirUri: curent_bytes(count) of total_bytes(count).
@@ -554,9 +556,7 @@ fallback_retry:
         auto destFileName = FileUtils::isFileDirectory(m_current_dest_dir_uri) ? nullptr : m_current_dest_dir_uri;
         //NOTE: mkdir doesn't have a progress callback.
         Q_EMIT FileProgressCallback(m_current_src_uri, destFileName, fileIconName, node->size(), node->size());
-        g_file_make_directory(destFile.get()->get(),
-                              getCancellable().get()->get(),
-                              &err);
+        g_file_make_directory(destFile.get()->get(),getCancellable().get()->get(), &err);
         if (err) {
             FileOperationError except;
             if (err->code == G_IO_ERROR_CANCELLED) {


### PR DESCRIPTION
…s bar does not show the file name

[LINK] http://172.17.66.192/biz/bug-view-21196.html

由于移动文件的时候，传入的目标文件是文件夹，而进度条不会显示文件夹路径，导致此问题。
关于进度条不显示文件夹路径的原因，假如进度条显示文件夹路径，那么会在复制大量小文件时候频繁在文件夹名字和文件名之间切换，造成进度条文件名的闪烁（另一个bug）