### PR TITLE
limited the max length of format name

### DIFF
--- a/libpeony-qt/windows/format_dialog.cpp
+++ b/libpeony-qt/windows/format_dialog.cpp
@@ -97,7 +97,7 @@ void Format_Dialog::acceptFormat(bool)
     //get values from ui
     strncpy(rom_size,ui->comboBox_rom_size->itemText(0).toUtf8().constData(),sizeof(ui->comboBox_rom_size->itemText(0).toUtf8().constData())-1);
     strncpy(rom_type,ui->comboBox_system->currentText().toUtf8().constData(),sizeof(ui->comboBox_system->currentText().toUtf8().constData())-1);
-    strncpy(rom_name,ui->lineEdit_device_name->text().toUtf8().constData(),sizeof(ui->lineEdit_device_name->text().toUtf8().constData())-1);
+    strcpy(rom_name,ui->lineEdit_device_name->text().toUtf8().constData());
 
     quick_clean = ui->checkBox_clean_or_not->isChecked();
 

--- a/libpeony-qt/windows/format_dialog.ui
+++ b/libpeony-qt/windows/format_dialog.ui
@@ -85,6 +85,9 @@
      <width>291</width>
      <height>26</height>
     </rect>
+</property>
+    <property name="maxLength">
+    <number>11</number>
    </property>
   </widget>
   <widget class="QCheckBox" name="checkBox_clean_or_not">


### PR DESCRIPTION
1.limited the format name length in 11.
2.slove the name cannot save while input the format name over 8