### PR TITLE
[FIX]  Parallel operation is not allowed to cancel file operation crash

### DIFF
--- a/libpeony-qt/file-operation/file-operation-progress-bar.cpp
+++ b/libpeony-qt/file-operation/file-operation-progress-bar.cpp
@@ -79,7 +79,7 @@ ProgressBar *FileOperationProgressBar::addFileOperation()
 
     li->setFlags(Qt::NoItemFlags);
 
-    connect(proc, &ProgressBar::finished, this, &FileOperationProgressBar::removeFileOperation);
+    proc->connect(proc, &ProgressBar::finished, this, &FileOperationProgressBar::removeFileOperation);
     ++m_progress_size;
 
     if (nullptr == m_current_main) {
@@ -121,7 +121,7 @@ void FileOperationProgressBar::removeFileOperation(ProgressBar *progress)
     }
 
     // free progress
-    delete progress;
+    progress->deleteLater();
     delete li;
 
     if (m_progress_size <= 0) {


### PR DESCRIPTION
[LINK] http://172.17.66.192/biz/bug-view-21252.html

不允許並行文件操作，取消操作文件崩潰問題