### PR TITLE
给桌面添加黑白名单功能

### DIFF
--- a/debian/copyright
+++ b/debian/copyright
@@ -272,6 +272,12 @@ License: GPL-3+
 
 Files: peony-qt-desktop/desktop-icon-view.cpp
   peony-qt-desktop/desktop-index-widget.cpp
+  peony-qt-desktop/bw-list-info.cpp
+  peony-qt-desktop/bw-list-info.h
+  peony-qt-desktop/peony-dbus-service.cpp
+  peony-qt-desktop/peony-dbus-service.h
+  peony-qt-desktop/peony-json-operation.cpp
+  peony-qt-desktop/peony-json-operation.h
 Copyright: 2019, 2020, Tianjin KYLIN Information Technology Co., Ltd.
 License: GPL-3+
 

--- a/libpeony-qt/file-info-job.cpp
+++ b/libpeony-qt/file-info-job.cpp
@@ -269,6 +269,7 @@ void FileInfoJob::refreshInfoContents(GFileInfo *new_info)
     m_info->m_colors = FileLabelModel::getGlobalModel()->getFileColors(m_info->uri());
 
     if (info->isDesktopFile()) {
+        info->m_desktop_name = info->displayName();
         QUrl url = info->uri();
         GDesktopAppInfo *desktop_info = g_desktop_app_info_new_from_filename(url.path().toUtf8());
         if (!desktop_info) {

--- a/libpeony-qt/file-info.h
+++ b/libpeony-qt/file-info.h
@@ -167,6 +167,11 @@ public:
     QString displayName() {
         return m_display_name;
     }
+
+    QString desktopName(){
+        return m_desktop_name;
+    }
+
     QString iconName() {
         return m_icon_name;
     }
@@ -324,6 +329,7 @@ private:
     bool m_is_loaded = false;
 
     QString m_display_name = nullptr;
+    QString m_desktop_name = nullptr;
     QString m_icon_name = nullptr;
     QString m_symbolic_icon_name = nullptr;
     QString m_file_id = nullptr;

--- a/peony-qt-desktop/bw-list-info.cpp
+++ b/peony-qt-desktop/bw-list-info.cpp
@@ -74,7 +74,7 @@ bool BWListInfo::isBlackListMode()
 
 bool BWListInfo::isWriteListMode()
 {
-    return m_workModel == BW_LIST_WRITE;
+    return m_workModel == BW_LIST_WHITE;
 }
 
 bool BWListInfo::isNormalMode()

--- a/peony-qt-desktop/bw-list-info.cpp
+++ b/peony-qt-desktop/bw-list-info.cpp
@@ -57,6 +57,8 @@ int BWListInfo::clearBWlist()
     {
         m_bwListInfo.clear();
     }
+
+    m_workModel = BW_LIST_NORMAL;
 }
 
 bool BWListInfo::desktopNameExist(QString desktop)

--- a/peony-qt-desktop/bw-list-info.cpp
+++ b/peony-qt-desktop/bw-list-info.cpp
@@ -1,0 +1,81 @@
+/*
+ * Peony-Qt
+ *
+ * Copyright (C) 2020, KylinSoft Co., Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Authors: renpeijia <renpeijia@kylinos.cn>
+ *
+ */
+
+#include "bw-list-info.h"
+
+using namespace Peony;
+
+BWListInfo::BWListInfo(QObject *parent):QObject(parent)
+{
+    m_workModel = BW_LIST_NORMAL;
+}
+
+BWListInfo::~BWListInfo()
+{
+    clearBWlist();
+}
+
+void BWListInfo::setBWListModel(QString model)
+{
+    m_workModel = model;
+}
+
+int BWListInfo::addBWListElement(QString desktopName)
+{
+    QStringList strList = desktopName.split("/");
+   // qDebug()<<"add bw list element" << strList.last();
+    m_bwListInfo.insert(strList.last());
+}
+
+int BWListInfo::delBWListElement(QString desktopName)
+{
+    m_bwListInfo.remove(desktopName);
+}
+
+int BWListInfo::clearBWlist()
+{
+    if (!m_bwListInfo.isEmpty())
+    {
+        m_bwListInfo.clear();
+    }
+}
+
+bool BWListInfo::desktopNameExist(QString desktop)
+{
+    //qDebug()<<"check desktop exsit" << desktop;
+    return m_bwListInfo.contains(desktop);
+}
+
+bool BWListInfo::isBlackListMode()
+{
+    return m_workModel == BW_LIST_BLACK;
+}
+
+bool BWListInfo::isWriteListMode()
+{
+    return m_workModel == BW_LIST_WRITE;
+}
+
+bool BWListInfo::isNormalMode()
+{
+    return m_workModel == BW_LIST_NORMAL;
+}

--- a/peony-qt-desktop/bw-list-info.h
+++ b/peony-qt-desktop/bw-list-info.h
@@ -1,0 +1,61 @@
+/*
+ * Peony-Qt
+ *
+ * Copyright (C) 2020, KylinSoft Co., Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Authors: renpeijia <renpeijia@kylinos.cn>
+ *
+ */
+
+#ifndef BWLISTINFO_H
+#define BWLISTINFO_H
+
+#include <QSet>
+#include <QDebug>
+
+
+namespace Peony {
+
+#define BW_LIST_NORMAL  "normal"
+#define BW_LIST_BLACK   "blacklist"
+#define BW_LIST_WRITE   "whitelist"
+
+class BWListInfo:public QObject
+{
+    Q_OBJECT
+
+public:
+    explicit BWListInfo(QObject *parent = nullptr);
+    ~BWListInfo();
+
+public:
+    void setBWListModel(QString model);
+    int addBWListElement(QString desktopName);
+    int delBWListElement(QString desktopName);
+    int clearBWlist();
+    bool desktopNameExist(QString desktop);
+
+    bool isBlackListMode();
+    bool isWriteListMode();
+    bool isNormalMode();
+
+private:
+    QSet<QString> m_bwListInfo;
+    QString m_workModel;
+};
+
+}
+#endif // BWLISTINFO_H

--- a/peony-qt-desktop/bw-list-info.h
+++ b/peony-qt-desktop/bw-list-info.h
@@ -31,7 +31,7 @@ namespace Peony {
 
 #define BW_LIST_NORMAL  "normal"
 #define BW_LIST_BLACK   "blacklist"
-#define BW_LIST_WRITE   "whitelist"
+#define BW_LIST_WHITE   "whitelist"
 
 class BWListInfo:public QObject
 {

--- a/peony-qt-desktop/desktop-icon-view.cpp
+++ b/peony-qt-desktop/desktop-icon-view.cpp
@@ -232,11 +232,15 @@ DesktopIconView::DesktopIconView(QWidget *parent) : QListView(parent)
     setModel(m_proxy_model);
     //m_proxy_model->sort(0);
 
+    m_peonyDbusSer = new PeonyDbusService(this);
+    m_peonyDbusSer->dbusServerRegister();
+
     this->refresh();
 }
 
 DesktopIconView::~DesktopIconView()
 {
+    delete m_peonyDbusSer;
     //saveAllItemPosistionInfos();
 }
 
@@ -1488,4 +1492,15 @@ QRect DesktopIconView::visualRect(const QModelIndex &index) const
     }
     rect.moveTo(rect.topLeft() + p);
     return rect;
+}
+
+int DesktopIconView::updateBWList()
+{
+    m_proxy_model->updateBlackAndWriteLists();
+    /*
+    * 重新按照既定规则排序，这样可以避免出现空缺和图标重叠的情况
+    */
+    int sortType = GlobalSettings::getInstance()->getValue(LAST_DESKTOP_SORT_ORDER).toInt();
+    setSortType(sortType);
+    return 0;
 }

--- a/peony-qt-desktop/desktop-icon-view.h
+++ b/peony-qt-desktop/desktop-icon-view.h
@@ -25,6 +25,7 @@
 
 #include <QListView>
 #include "directory-view-plugin-iface.h"
+#include "peony-dbus-service.h"
 
 #include <QStandardPaths>
 #include <QTimer>
@@ -35,6 +36,7 @@ namespace Peony {
 
 class DesktopItemModel;
 class DesktopItemProxyModel;
+class PeonyDbusService;
 
 class DesktopIconView : public QListView, public DirectoryViewIface
 {
@@ -92,6 +94,7 @@ public:
 
     QRect visualRect(const QModelIndex &index) const;
     const QFont getViewItemFont(QStyleOptionViewItem *item);
+    int updateBWList();
 
 Q_SIGNALS:
     void zoomLevelChanged(ZoomLevel level);
@@ -233,6 +236,8 @@ private:
     QModelIndexList m_drag_indexes;
 
     QHash<QString, QRect> m_item_rect_hash;
+
+    PeonyDbusService *m_peonyDbusSer;
 };
 
 }

--- a/peony-qt-desktop/desktop-item-proxy-model.cpp
+++ b/peony-qt-desktop/desktop-item-proxy-model.cpp
@@ -27,6 +27,7 @@
 #include "file-operation-utils.h"
 #include "global-settings.h"
 
+#include <QDir>
 #include <QDebug>
 
 using namespace Peony;
@@ -48,6 +49,19 @@ DesktopItemProxyModel::DesktopItemProxyModel(QObject *parent) : QSortFilterProxy
     auto settings = GlobalSettings::getInstance();
     m_show_hidden = settings->isExist("show-hidden")? settings->getValue("show-hidden").toBool(): false;
     //qDebug() <<"DesktopItemProxyModel:" <<settings->isExist("show-hidden")<<m_show_hidden;
+
+    m_bwListInfo = new BWListInfo();
+    m_jsonOp = new PeonyJsonOperation();
+    QString jsonPath=QDir::homePath()+"/.config/peony-security-config.json";
+    m_jsonOp->setConfigFile(jsonPath);
+    m_jsonOp->loadConfigFile();
+    m_jsonOp->getBWListInfo(m_bwListInfo);
+}
+
+DesktopItemProxyModel::~DesktopItemProxyModel()
+{
+    delete m_jsonOp;
+    delete m_bwListInfo;
 }
 
 bool DesktopItemProxyModel::filterAcceptsRow(int source_row, const QModelIndex &source_parent) const
@@ -65,6 +79,15 @@ bool DesktopItemProxyModel::filterAcceptsRow(int source_row, const QModelIndex &
     if (! m_show_hidden && info->displayName().startsWith(".")) {
         return false;
     }
+
+    if (info->isDesktopFile() && nullptr != info->desktopName()){
+        if (m_bwListInfo->isBlackListMode()){
+            return !m_bwListInfo->desktopNameExist(info->desktopName());
+        } else if (m_bwListInfo->isWriteListMode()){
+            return m_bwListInfo->desktopNameExist(info->desktopName());
+        }
+    }
+
     return true;
 }
 
@@ -149,4 +172,14 @@ void DesktopItemProxyModel::setShowHidden(bool showHidden)
     GlobalSettings::getInstance()->setValue("show-hidden", showHidden);
     m_show_hidden = showHidden;
     invalidateFilter();
+}
+
+int DesktopItemProxyModel::updateBlackAndWriteLists()
+{
+    m_bwListInfo->clearBWlist();
+    m_jsonOp->loadConfigFile();
+    m_jsonOp->getBWListInfo(m_bwListInfo);
+    //重新过滤显示
+    invalidateFilter();
+    return 0;
 }

--- a/peony-qt-desktop/desktop-item-proxy-model.cpp
+++ b/peony-qt-desktop/desktop-item-proxy-model.cpp
@@ -54,8 +54,7 @@ DesktopItemProxyModel::DesktopItemProxyModel(QObject *parent) : QSortFilterProxy
     m_jsonOp = new PeonyJsonOperation();
     QString jsonPath=QDir::homePath()+"/.config/peony-security-config.json";
     m_jsonOp->setConfigFile(jsonPath);
-    m_jsonOp->loadConfigFile();
-    m_jsonOp->getBWListInfo(m_bwListInfo);
+    m_jsonOp->loadConfigFile(m_bwListInfo);
 }
 
 DesktopItemProxyModel::~DesktopItemProxyModel()
@@ -177,8 +176,7 @@ void DesktopItemProxyModel::setShowHidden(bool showHidden)
 int DesktopItemProxyModel::updateBlackAndWriteLists()
 {
     m_bwListInfo->clearBWlist();
-    m_jsonOp->loadConfigFile();
-    m_jsonOp->getBWListInfo(m_bwListInfo);
+    m_jsonOp->loadConfigFile(m_bwListInfo);
     //重新过滤显示
     invalidateFilter();
     return 0;

--- a/peony-qt-desktop/desktop-item-proxy-model.h
+++ b/peony-qt-desktop/desktop-item-proxy-model.h
@@ -24,6 +24,8 @@
 #define DESKTOPITEMPROXYMODEL_H
 
 #include <QSortFilterProxyModel>
+#include "bw-list-info.h"
+#include "peony-json-operation.h"
 
 namespace Peony {
 
@@ -39,6 +41,7 @@ public:
         Other
     };
     explicit DesktopItemProxyModel(QObject *parent = nullptr);
+    ~DesktopItemProxyModel();
 
     void setSortType(int type) {
         m_sort_type = type;
@@ -48,6 +51,7 @@ public:
     }
 
     void setShowHidden(bool showHidden);
+    int updateBlackAndWriteLists();
 
     bool filterAcceptsRow(int source_row, const QModelIndex &source_parent) const;
     bool lessThan(const QModelIndex &source_left, const QModelIndex &source_right) const;
@@ -55,6 +59,9 @@ public:
 private:
     int m_sort_type = Other;
     bool m_show_hidden;
+
+    BWListInfo    *m_bwListInfo;
+    PeonyJsonOperation *m_jsonOp;
 };
 
 }

--- a/peony-qt-desktop/peony-dbus-service.cpp
+++ b/peony-qt-desktop/peony-dbus-service.cpp
@@ -1,0 +1,58 @@
+/*
+ * Peony-Qt
+ *
+ * Copyright (C) 2020, KylinSoft Co., Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Authors: renpeijia <renpeijia@kylinos.cn>
+ *
+ */
+
+#include "desktop-icon-view.h"
+#include "peony-dbus-service.h"
+#include <QDBusConnection>
+#include <QDBusConnectionInterface>
+
+#include <QDebug>
+using namespace Peony;
+
+PeonyDbusService::PeonyDbusService(DesktopIconView *view, QObject *parent) : QObject(parent)
+{
+    m_desktopIconView = view;
+}
+
+PeonyDbusService::~PeonyDbusService()
+{
+    m_desktopIconView = nullptr;
+}
+
+int PeonyDbusService::dbusServerRegister()
+{
+    QDBusConnection::sessionBus().unregisterService("org.ukui.peony.service");
+    QDBusConnection::sessionBus().registerService("org.ukui.peony.service");
+    QDBusConnection::sessionBus().registerObject("/org/ukui/peony", this, QDBusConnection :: ExportAllSlots);
+}
+
+QString PeonyDbusService::getSecurityConfigPath()
+{
+    QString jsonPath=QDir::homePath()+"/.config/peony-security-config.json";
+
+    return jsonPath;
+}
+
+int PeonyDbusService::reloadSecurityConfig()
+{
+    m_desktopIconView->updateBWList();
+}

--- a/peony-qt-desktop/peony-dbus-service.h
+++ b/peony-qt-desktop/peony-dbus-service.h
@@ -1,0 +1,65 @@
+/*
+ * Peony-Qt
+ *
+ * Copyright (C) 2020, KylinSoft Co., Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Authors: renpeijia <renpeijia@kylinos.cn>
+ *
+ */
+
+#ifndef PEONYDBUSSERVICE_H
+#define PEONYDBUSSERVICE_H
+
+#include "desktop-icon-view.h"
+#include <QCoreApplication>
+#include <QTimer>
+#include <QtDBus>
+#include <QDebug>
+#include <QObject>
+
+/*
+名称：org.ukui.peony
+对象路径：/org/ukui/peony
+接口：org.ukui.peony
+方法：GetSecurityConfigPath()//获取安全配置文件存放路径
+     ReloadSecurityConfig()// 重新加载安全配置
+*/
+
+namespace Peony {
+
+class DesktopIconView;
+
+class PeonyDbusService:public QObject
+{
+    Q_OBJECT
+    Q_CLASSINFO("D-Bus Interface", "org.ukui.peony")
+
+public:    
+    explicit PeonyDbusService(DesktopIconView *view, QObject *parent=nullptr);
+    ~PeonyDbusService();
+
+   int dbusServerRegister();
+
+public Q_SLOTS:
+    QString getSecurityConfigPath();
+    int reloadSecurityConfig();
+
+private:
+    DesktopIconView *m_desktopIconView = nullptr;
+};
+
+}
+#endif // PEONYDBUSSERVICE_H

--- a/peony-qt-desktop/peony-json-operation.cpp
+++ b/peony-qt-desktop/peony-json-operation.cpp
@@ -1,0 +1,195 @@
+/*
+ * Peony-Qt
+ *
+ * Copyright (C) 2020, KylinSoft Co., Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Authors: renpeijia <renpeijia@kylinos.cn>
+ *
+ */
+#include "peony-json-operation.h"
+#include "bw-list-info.h"
+#include <QFile>
+#include <QFileInfo>
+#include <errno.h>
+
+using namespace Peony;
+
+PeonyJsonOperation::PeonyJsonOperation(QObject *parent):QObject(parent)
+{
+    m_configFile = nullptr;
+}
+
+PeonyJsonOperation::~PeonyJsonOperation()
+{
+    m_configFile = nullptr;
+}
+
+void PeonyJsonOperation::setConfigFile(QString configFile)
+{
+    //qDebug()<<"the configfile :" << configFile;
+    m_configFile = configFile;
+}
+
+int PeonyJsonOperation::loadConfigFile()
+{
+    //1、judge file exsit?
+    QFileInfo file(m_configFile);
+    if (!file.exists()){
+        qWarning("config file %s do not exist", m_configFile);
+        return -EEXIST;
+    }
+
+    //2、read json file
+    QFile jsonFile(m_configFile);
+    if (!jsonFile.open(QIODevice::ReadOnly)){
+        qWarning("open file %s failed, errno[%d]", m_configFile, errno);
+        return -errno;
+    }
+    QByteArray jsonCtxt = jsonFile.readAll();
+    jsonFile.close();
+
+    if (jsonCtxt.isEmpty()){
+        qWarning("get json context failed, or is empty");
+        return -EINVAL;
+    }
+
+    //3、load json file
+    QJsonParseError jsonerror;
+    m_jsonDoc = QJsonDocument::fromJson(jsonCtxt, &jsonerror);
+    if (m_jsonDoc.isNull() || jsonerror.error != QJsonParseError::NoError){
+        qWarning("json load file %s failed, errno[%d]", m_configFile, jsonerror.error);
+        return -EINVAL;
+    }
+
+    return 0;
+}
+
+void PeonyJsonOperation::releaseConfigFile()
+{
+
+}
+
+int PeonyJsonOperation::getBWListInfo(BWListInfo *bwListInfo)
+{
+    QJsonObject jsonObj = m_jsonDoc.object();
+    if (!jsonObj.contains("ukui-peony")) {
+        qWarning("the json file is not ukui-peony");
+        return -EINVAL;
+    }
+
+    QJsonObject peonyObj = jsonObj.value("ukui-peony").toObject();
+    if (!peonyObj.contains("mode")) {
+        qWarning("the json file does not contain model");
+        return -EINVAL;
+    }
+
+    QString model = peonyObj.value("mode").toString();
+    qDebug()<<"bw list mode:"<< model;
+    if (BW_LIST_BLACK == model) {
+        bwListInfo->setBWListModel(model);
+        if (peonyObj.contains(BW_LIST_BLACK)) {
+            QJsonValue bPkgValue = peonyObj.value(BW_LIST_BLACK);
+            return bwPkgInfoParse(bPkgValue, bwListInfo);
+        }
+    } else if (BW_LIST_WRITE == model){
+        bwListInfo->setBWListModel(model);
+        if (peonyObj.contains(BW_LIST_WRITE)) {
+            QJsonValue wPkgValue = peonyObj.value(BW_LIST_WRITE);
+            return bwPkgInfoParse(wPkgValue, bwListInfo);
+        }
+    } else if (BW_LIST_NORMAL == model){
+        bwListInfo->setBWListModel(model);
+    } else {
+        qWarning("the mode %s is undefined", model);
+        return -EINVAL;
+    }
+
+    return 0;
+}
+
+int PeonyJsonOperation::bwPkgInfoParse(QJsonValue &bwPkgValue, BWListInfo *bwListInfo)
+{
+    if (!bwPkgValue.isArray()) {
+        qWarning("the pkg info format is not array");
+        return -EINVAL;
+    }
+
+    QJsonArray pkgInfoArray = bwPkgValue.toArray();
+    int pkgCnt = pkgInfoArray.size();
+    for (int i = 0; i < pkgCnt; i++)
+    {
+        QJsonValue pkgElementValue = pkgInfoArray.at(i);
+        if (!pkgElementValue.isObject()) {
+            qWarning("the format of pkg element is not object");
+            return -EINVAL;
+        }
+
+        QJsonObject pkgElementObj = pkgElementValue.toObject();
+        if (!pkgElementObj.contains("entries")) {
+            qWarning("the pkg info do not contain element entries");
+            return -EINVAL;
+        }
+
+        QJsonValue entryInfoValue = pkgElementObj.value("entries");
+        entryInfoParse(entryInfoValue, bwListInfo);
+    }
+
+    return 0;
+}
+
+int PeonyJsonOperation::entryInfoParse(QJsonValue &entryInfoValue, BWListInfo *bwListInfo)
+{
+    if (!entryInfoValue.isArray()) {
+        qWarning("the app config is not array");
+        return -EINVAL;
+    }
+
+    QJsonArray entryInfoArray = entryInfoValue.toArray();
+    int entryCnt = entryInfoArray.size();
+    for (int i = 0; i < entryCnt; i++) {
+        QJsonValue appValue = entryInfoArray.at(i);
+        if (!appValue.isObject()) {
+            qWarning("the app config array element is not object");
+            return -EINVAL;
+        }
+
+        QJsonObject appObj = appValue.toObject();
+        if (!appObj.contains("path") || !appObj.contains("visible")) {
+            qWarning("the config do not contain element path or visible");
+            return -EINVAL;
+        }
+
+        QJsonValue visibleValue = appObj.value("visible");
+        if (!visibleValue.isBool()){
+            qWarning("visible element is not bool");
+            return -EINVAL;
+        }
+
+        QJsonValue pathValue = appObj.value("path");
+        if (!pathValue.isString()){
+            qWarning("path element is not string");
+            return -EINVAL;
+        }
+
+        bool appVisible = visibleValue.toBool();
+        if (appVisible) {
+            QString appPath = pathValue.toString();
+            bwListInfo->addBWListElement(appPath);
+        }
+    }
+
+    return 0;
+}

--- a/peony-qt-desktop/peony-json-operation.cpp
+++ b/peony-qt-desktop/peony-json-operation.cpp
@@ -43,7 +43,7 @@ void PeonyJsonOperation::setConfigFile(QString configFile)
     m_configFile = configFile;
 }
 
-int PeonyJsonOperation::loadConfigFile()
+int PeonyJsonOperation::loadConfigFile(BWListInfo *bwListInfo)
 {
     //1、judge file exsit?
     QFileInfo file(m_configFile);
@@ -68,11 +68,13 @@ int PeonyJsonOperation::loadConfigFile()
 
     //3、load json file
     QJsonParseError jsonerror;
-    m_jsonDoc = QJsonDocument::fromJson(jsonCtxt, &jsonerror);
-    if (m_jsonDoc.isNull() || jsonerror.error != QJsonParseError::NoError){
+    QJsonDocument jsonDoc = QJsonDocument::fromJson(jsonCtxt, &jsonerror);
+    if (jsonDoc.isNull() || jsonerror.error != QJsonParseError::NoError){
         qWarning("json load file %s failed, errno[%d]", m_configFile, jsonerror.error);
         return -EINVAL;
     }
+
+    getBWListInfo(jsonDoc, bwListInfo);
 
     return 0;
 }
@@ -82,9 +84,9 @@ void PeonyJsonOperation::releaseConfigFile()
 
 }
 
-int PeonyJsonOperation::getBWListInfo(BWListInfo *bwListInfo)
+int PeonyJsonOperation::getBWListInfo(QJsonDocument &jsonDoc, BWListInfo *bwListInfo)
 {
-    QJsonObject jsonObj = m_jsonDoc.object();
+    QJsonObject jsonObj = jsonDoc.object();
     if (!jsonObj.contains("ukui-peony")) {
         qWarning("the json file is not ukui-peony");
         return -EINVAL;

--- a/peony-qt-desktop/peony-json-operation.cpp
+++ b/peony-qt-desktop/peony-json-operation.cpp
@@ -106,10 +106,10 @@ int PeonyJsonOperation::getBWListInfo(QJsonDocument &jsonDoc, BWListInfo *bwList
             QJsonValue bPkgValue = peonyObj.value(BW_LIST_BLACK);
             return bwPkgInfoParse(bPkgValue, bwListInfo);
         }
-    } else if (BW_LIST_WRITE == model){
+    } else if (BW_LIST_WHITE == model){
         bwListInfo->setBWListModel(model);
-        if (peonyObj.contains(BW_LIST_WRITE)) {
-            QJsonValue wPkgValue = peonyObj.value(BW_LIST_WRITE);
+        if (peonyObj.contains(BW_LIST_WHITE)) {
+            QJsonValue wPkgValue = peonyObj.value(BW_LIST_WHITE);
             return bwPkgInfoParse(wPkgValue, bwListInfo);
         }
     } else if (BW_LIST_NORMAL == model){

--- a/peony-qt-desktop/peony-json-operation.h
+++ b/peony-qt-desktop/peony-json-operation.h
@@ -47,15 +47,14 @@ public:
 
 public:
     void setConfigFile(QString configFile);
-    int  loadConfigFile();
-    int  getBWListInfo(BWListInfo *bwListInfo);
+    int  loadConfigFile(BWListInfo *bwListInfo);
     void releaseConfigFile();
 
 private:
+    int getBWListInfo(QJsonDocument &jsonDoc, BWListInfo *bwListInfo);
     int bwPkgInfoParse(QJsonValue &bwPkgValue, BWListInfo *bwListInfo);
     int entryInfoParse(QJsonValue &entryInfoValue, BWListInfo *bwListInfo);
     QString   m_configFile;
-    QJsonDocument m_jsonDoc;
 };
 
 }

--- a/peony-qt-desktop/peony-json-operation.h
+++ b/peony-qt-desktop/peony-json-operation.h
@@ -1,0 +1,63 @@
+/*
+ * Peony-Qt
+ *
+ * Copyright (C) 2020, KylinSoft Co., Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Authors: renpeijia <renpeijia@kylinos.cn>
+ *
+ */
+
+#ifndef PEONYJSONOPERATION_H
+#define PEONYJSONOPERATION_H
+
+#include <QCoreApplication>
+#include <QJsonDocument>
+#include <QJsonArray>
+#include <QJsonObject>
+#include <QJsonParseError>
+#include <QJsonValue>
+#include <QString>
+#include <QStringList>
+#include <QDebug>
+
+namespace Peony {
+
+class BWListInfo;
+
+class PeonyJsonOperation:public QObject
+{
+    Q_OBJECT
+
+public:
+    explicit PeonyJsonOperation(QObject *parent=nullptr);
+    ~PeonyJsonOperation();
+
+public:
+    void setConfigFile(QString configFile);
+    int  loadConfigFile();
+    int  getBWListInfo(BWListInfo *bwListInfo);
+    void releaseConfigFile();
+
+private:
+    int bwPkgInfoParse(QJsonValue &bwPkgValue, BWListInfo *bwListInfo);
+    int entryInfoParse(QJsonValue &entryInfoValue, BWListInfo *bwListInfo);
+    QString   m_configFile;
+    QJsonDocument m_jsonDoc;
+};
+
+}
+
+#endif // PEONYJSONOPERATION_H

--- a/peony-qt-desktop/peony-qt-desktop.pro
+++ b/peony-qt-desktop/peony-qt-desktop.pro
@@ -52,7 +52,10 @@ SOURCES += \
     desktop-index-widget.cpp \
     desktop-menu.cpp \
     desktop-menu-plugin-manager.cpp \
-    desktop-item-proxy-model.cpp
+    desktop-item-proxy-model.cpp \
+    peony-json-operation.cpp \
+    bw-list-info.cpp \
+    peony-dbus-service.cpp
 
 HEADERS += \
     desktop-screen.h \
@@ -65,7 +68,10 @@ HEADERS += \
     desktop-index-widget.h \
     desktop-menu.h \
     desktop-menu-plugin-manager.h \
-    desktop-item-proxy-model.h
+    desktop-item-proxy-model.h \
+    peony-json-operation.h \
+    bw-list-info.h \
+    peony-dbus-service.h
 
 target.path = /usr/bin
 !isEmpty(target.path): INSTALLS += target


### PR DESCRIPTION
1、当设置黑名单时，黑名单的desktop文件不在桌面显示
2、当设置白名单时，桌面只显示白名单中的desktop文件
3、当设置成正常莫模式时，不对desktop文件进行过滤，所有的desktop文件都会显示在桌面

自测用例：
1、对黑名单模式、白名单模式和正常模式，进行通过dbus接口通知桌面更新以及系统重启测试；
2、当配置文件不存在时，通过dbus接口通知桌面更新以及系统重启测试；
3、当配置文件为空时，通过dbus接口通知桌面更新以及系统重启测试；
4、当黑白名单为空的时候，对黑名单模式、白名单模式和正常模式，进行通过dbus接口通知桌面更新以及系统重启测试；