### PR TITLE
    fix bug: 19204

### DIFF
--- a/libpeony-qt/file-operation/file-untrash-operation.cpp
+++ b/libpeony-qt/file-operation/file-untrash-operation.cpp
@@ -23,7 +23,7 @@
 #include "file-utils.h"
 #include "file-untrash-operation.h"
 #include "file-operation-manager.h"
-
+#include <QMessageBox>
 #include <QUrl>
 
 using namespace Peony;
@@ -53,7 +53,6 @@ void FileUntrashOperation::cacheOriginalUri()
                                   getCancellable().get()->get(),
                                   nullptr));
         auto origin_path = g_file_info_get_attribute_byte_string(info.get()->get(), G_FILE_ATTRIBUTE_TRASH_ORIG_PATH);
-        qDebug()<<"orig-path"<<origin_path;
 
         auto destFile = wrapGFile(g_file_new_for_path(origin_path));
         auto originUri = FileUtils::getFileUri(destFile);
@@ -200,6 +199,134 @@ void FileUntrashOperation::getBackupName(
     return;
 }
 
+int FileUntrashOperation::copyFileProcess(QString &srcFile, QString &destFile)
+{
+    int ret = 0;
+    GError *err = nullptr;
+
+    auto file = wrapGFile(g_file_new_for_uri(srcFile.toUtf8().constData()));
+    auto originFile = wrapGFile(g_file_new_for_uri(destFile.toUtf8().constData()));
+
+    g_file_copy(file.get()->get(),
+                originFile.get()->get(),
+                GFileCopyFlags(m_default_copy_flag|G_FILE_COPY_OVERWRITE),
+                getCancellable().get()->get(),
+                nullptr,
+                nullptr,
+                &err);
+    if (err) {
+        ret = -err->code;
+        qWarning()<< "copy file :" << srcFile
+                  << " Error info:" << err->message
+                  << " Error code:" << ret;
+
+        QMessageBox::critical(nullptr, tr("copy Error"),
+                         "copy file Error:" + QString::number(ret));
+        g_error_free(err);
+    }
+
+    return ret;
+}
+
+int FileUntrashOperation::moveRecursively(FileNode *fileNode, QString &parentPath)
+{
+    int ret = 0;
+    QString srcFile = fileNode->uri();
+    QString destPath = parentPath + '/' + fileNode->baseName();
+
+    if (fileNode->isFolder()) {
+        if (!FileUtils::isFileExsit(destPath)){
+            //如果目录不存在，则创建
+            GError *err = nullptr;
+            auto originFile = wrapGFile(g_file_new_for_uri(destPath.toUtf8().constData()));
+            g_file_make_directory(originFile.get()->get(),
+                                  getCancellable().get()->get(),
+                                  &err);
+            if (err) {
+                ret = -err->code;
+                qWarning()<< "make dir:" << srcFile
+                          << " Error info:" << err->message
+                          << " Error code:" << ret;
+
+                QMessageBox::critical(nullptr, tr("mkdir Error"),
+                                 "create directory Error:" + QString::number(ret));
+
+                g_error_free(err);
+                return ret;
+            }
+        }
+
+        for (auto child : *(fileNode->children())) {
+            int ret = moveRecursively(child, destPath);
+            if (ret < 0) {
+                return ret;
+            }
+        }
+    } else {
+        int ret = copyFileProcess(srcFile, destPath);
+        if (ret < 0) {
+            return ret;
+        }
+    }
+
+    return 0;
+}
+
+int FileUntrashOperation::deleteFileProcess(FileNode *fileNode)
+{
+    int ret = 0;
+    GError *err = nullptr;
+
+    QString srcFile = fileNode->uri();
+    GFile *file = g_file_new_for_uri(srcFile.toUtf8().constData());
+
+    g_file_delete(file,
+                  getCancellable().get()->get(),
+                  &err);
+    if (err){
+        ret = -err->code;
+        qWarning()<< "delete file:" << srcFile
+                  << " Error info:" << err->message
+                  << " Error code:" << ret;
+
+        QMessageBox::critical(nullptr, tr("delete Error"),
+                        "delete file Error:" + QString::number(ret));
+
+        g_error_free(err);
+    }
+
+    return ret;
+}
+
+int FileUntrashOperation::untrashFileOverWrite(QString &uri)
+{
+    int ret = 0;
+
+    //1、通过树形结构，构建目录下的节点（文件和目录）
+    FileNode *node = new FileNode(uri, nullptr, nullptr);
+    node->findChildrenRecursively();
+
+    QString originParentPath = m_restore_hash.value(uri);
+
+    //2、对node的树形结构进行递归遍历处理
+    for (auto child : *(node->children())) {
+        ret = moveRecursively(child, originParentPath);
+        if (ret < 0)
+        {
+            goto l_free;
+        }
+    }
+
+    //3、删除回收站中的目录
+    ret = deleteFileProcess(node);
+
+    //4、释放filenode空间
+l_free:
+    delete node;
+
+    return ret;
+}
+
 void FileUntrashOperation::run()
 {
     /*!
@@ -207,6 +334,8 @@ void FileUntrashOperation::run()
       can not restore the files in desktop.
       it caused by the parent uri string has chinese.
       */
+    int ret = 0;
+
     for (auto uri : m_uris) {
         //cacheOriginalUri();
         auto originUri = m_restore_hash.value(uri);
@@ -251,22 +380,16 @@ retry:
                 cancel();
                 break;
             case OverWriteOne:
-                g_file_move(file.get()->get(),
-                            destFile.get()->get(),
-                            GFileCopyFlags(m_default_copy_flag|G_FILE_COPY_OVERWRITE),
-                            getCancellable().get()->get(),
-                            nullptr,
-                            nullptr,
-                            nullptr);
+                ret = untrashFileOverWrite(uri);
+                if (ret < 0){
+                    goto l_out;
+                }
                 break;
             case OverWriteAll:
-                g_file_move(file.get()->get(),
-                            destFile.get()->get(),
-                            GFileCopyFlags(m_default_copy_flag|G_FILE_COPY_OVERWRITE),
-                            getCancellable().get()->get(),
-                            nullptr,
-                            nullptr,
-                            nullptr);
+                ret = untrashFileOverWrite(uri);
+                if (ret < 0){
+                    goto l_out;
+                }
                 m_prehandle_hash.insert(except.errorCode, OverWriteOne);
                 break;
             case BackupOne: {
@@ -297,5 +420,6 @@ retry:
         }
     }
 
+l_out:
     operationFinished();
 }

--- a/libpeony-qt/file-operation/file-untrash-operation.h
+++ b/libpeony-qt/file-operation/file-untrash-operation.h
@@ -25,6 +25,7 @@
 
 #include "peony-core_global.h"
 #include "file-operation.h"
+#include "file-node.h"
 
 namespace Peony {
 
@@ -55,6 +56,11 @@ private:
                             QString &srcUri,
                             QString &originUri,
                             GError *err);
+    int untrashFileOverWrite(QString &uri);
+    int moveRecursively(FileNode *fileNode, QString &parentPath);
+    int copyFileProcess(QString &srcFile, QString &destFile);
+    int deleteFileProcess(FileNode *fileNode);
+
     GFileCopyFlags m_default_copy_flag = GFileCopyFlags(G_FILE_COPY_NOFOLLOW_SYMLINKS | G_FILE_COPY_ALL_METADATA);
 
     QStringList m_uris;


### PR DESCRIPTION
解决的问题：
    回收站还原文件的时候，遇到同名文件，选择替换，无法替换覆盖同名的文件

解决方案：
    将gio的move操作换成了，copy+delete的方式，如果copy或者是delete出现异常，将会弹窗提示，并终止继续操作。

自测用例：
1、将peony和peony插件打deb安装，文件管理器和桌面的基本操作的测试；
2、回收站还原文件：或略、备份、无同名文件和取消等基本操作的测试；
3、有同名文件选择替换：
     1）只有空目录的测试
     2）有文件和有目录测试
     3）有部分文件（目录）同名的测试
4、操作异常的测试：
     1）copy异常的测试
     2）删除回收站的文件（目录）异常测试