### PR TITLE
Calculated disk size by 1024 bytes

### DIFF
--- a/libpeony-qt/controls/preview-page/default-preview-page/default-preview-page.cpp
+++ b/libpeony-qt/controls/preview-page/default-preview-page/default-preview-page.cpp
@@ -290,7 +290,9 @@ void FilePreviewPage::countAsync(const QString &uri)
 void FilePreviewPage::updateCount()
 {
     m_file_count_label->setText(tr("%1 total, %2 hidden").arg(m_file_count).arg(m_hidden_count));
-    auto format = g_format_size(m_total_size);
+    //auto format = g_format_size(m_total_size);
+    //Calculated by 1024 bytes
+    auto format = g_format_size_full(m_total_size,G_FORMAT_SIZE_IEC_UNITS);
     m_total_size_label->setText(format);
     g_free(format);
 }

--- a/libpeony-qt/controls/property-page/basic-properties-page.cpp
+++ b/libpeony-qt/controls/property-page/basic-properties-page.cpp
@@ -293,7 +293,10 @@ void BasicPropertiesPage::cancelCount()
 void BasicPropertiesPage::updateCountInfo()
 {
     m_file_count_label->setText(tr("%1 files (include root files), %2 hidden").arg(m_file_count).arg(m_hidden_file_count));
-    auto format = g_format_size(m_total_size);
+   // auto format = g_format_size(m_total_size);
+   
+   //Calculated by 1024 bytes
+    auto format = g_format_size_full(m_total_size,G_FORMAT_SIZE_IEC_UNITS);
     m_total_size_label->setText(tr("%1 total").arg(format));
     g_free(format);
 }

--- a/libpeony-qt/controls/property-page/computer-properties-page.cpp
+++ b/libpeony-qt/controls/property-page/computer-properties-page.cpp
@@ -120,9 +120,14 @@ ComputerPropertiesPage::ComputerPropertiesPage(const QString &uri, QWidget *pare
             quint64 total = g_file_info_get_attribute_uint64(info, G_FILE_ATTRIBUTE_FILESYSTEM_SIZE);
             quint64 used = g_file_info_get_attribute_uint64(info, G_FILE_ATTRIBUTE_FILESYSTEM_USED);
             quint64 aviliable = g_file_info_get_attribute_uint64(info, G_FILE_ATTRIBUTE_FILESYSTEM_FREE);
-            char *total_format = g_format_size(total);
-            char *used_format = g_format_size(used);
-            char *aviliable_format = g_format_size(aviliable);
+            // char *total_format = g_format_size(total);
+            // char *used_format = g_format_size(used);
+            // char *aviliable_format = g_format_size(aviliable);
+            //Calculated by 1024 bytes
+            char *total_format = strtok(g_format_size_full(total,G_FORMAT_SIZE_IEC_UNITS),"iB");
+            char *used_format = strtok(g_format_size_full(used,G_FORMAT_SIZE_IEC_UNITS),"iB");
+            char *aviliable_format = strtok(g_format_size_full(aviliable,G_FORMAT_SIZE_IEC_UNITS),"iB");
+
             char *fs_type = g_file_info_get_attribute_as_string(info, G_FILE_ATTRIBUTE_FILESYSTEM_TYPE);
             m_layout->addRow(tr("Name: "), new QLabel(tr("File System"), this));
             m_layout->addRow(tr("Total Space: "), new QLabel(total_format, this));
@@ -152,9 +157,14 @@ ComputerPropertiesPage::ComputerPropertiesPage(const QString &uri, QWidget *pare
             quint64 total = g_file_info_get_attribute_uint64(info, G_FILE_ATTRIBUTE_FILESYSTEM_SIZE);
             quint64 used = g_file_info_get_attribute_uint64(info, G_FILE_ATTRIBUTE_FILESYSTEM_USED);
             quint64 aviliable = g_file_info_get_attribute_uint64(info, G_FILE_ATTRIBUTE_FILESYSTEM_FREE);
-            char *total_format = g_format_size(total);
-            char *used_format = g_format_size(used);
-            char *aviliable_format = g_format_size(aviliable);
+            //char *total_format = g_format_size(total);
+            //char *used_format = g_format_size(used);
+            //char *aviliable_format = g_format_size(aviliable);
+            //Calculated by 1024 bytes
+            char *total_format = strtok(g_format_size_full(total,G_FORMAT_SIZE_IEC_UNITS),"iB");
+            char *used_format = strtok(g_format_size_full(used,G_FORMAT_SIZE_IEC_UNITS),"iB");
+            char *aviliable_format = strtok(g_format_size_full(aviliable,G_FORMAT_SIZE_IEC_UNITS),"iB");           
+
             char *fs_type = g_file_info_get_attribute_as_string(info, G_FILE_ATTRIBUTE_FILESYSTEM_TYPE);
             m_layout->addRow(tr("Name: "), new QLabel(mount->name(), this));
             m_layout->addRow(tr("Total Space: "), new QLabel(total_format, this));

--- a/libpeony-qt/controls/status-bar/status-bar.cpp
+++ b/libpeony-qt/controls/status-bar/status-bar.cpp
@@ -78,7 +78,10 @@ void StatusBar::update()
                 size += selection->size();
             }
         }
-        auto format_size = g_format_size(size);
+        //auto format_size = g_format_size(size);
+        //Calculated by 1024 bytes
+        auto format_size = g_format_size_full(size,G_FORMAT_SIZE_IEC_UNITS);
+
         if (selections.count() == 1) {
             if (directoryCount == 1)
                 directoriesString = QString(", %1").arg(selections.first()->displayName());

--- a/libpeony-qt/file-info-job.cpp
+++ b/libpeony-qt/file-info-job.cpp
@@ -256,7 +256,7 @@ void FileInfoJob::refreshInfoContents(GFileInfo *new_info)
         content_type = nullptr;
     }
 
-    char *size_full = g_format_size_full(info->m_size, G_FORMAT_SIZE_DEFAULT);
+    char *size_full = strtok(g_format_size_full(info->m_size, G_FORMAT_SIZE_IEC_UNITS),"iB");
     info->m_file_size = size_full;
     g_free(size_full);
 

--- a/libpeony-qt/file-operation/file-operation-progress-bar.cpp
+++ b/libpeony-qt/file-operation/file-operation-progress-bar.cpp
@@ -696,7 +696,9 @@ void ProgressBar::onElementFoundOne(const QString &uri, const qint64 &size)
     m_total_size += size;
     QUrl url = uri;
     m_src_uri = url.toDisplayString();
-    char* format_size = g_format_size (quint64(m_total_size));
+    //char* format_size = g_format_size (quint64(m_total_size));
+    //Calculated by 1024 bytes
+    char* format_size = strtok(g_format_size_full(quint64(m_total_size),G_FORMAT_SIZE_IEC_UNITS),"iB");
 
     g_free(format_size);
 }

--- a/libpeony-qt/file-operation/file-operation-progress-wizard.cpp
+++ b/libpeony-qt/file-operation/file-operation-progress-wizard.cpp
@@ -152,7 +152,9 @@ void FileOperationProgressWizard::onElementFoundOne(const QString &uri, const qi
     m_total_count++;
     m_total_size += size;
 
-    char *format_size = g_format_size (quint64(m_total_size));
+    //char *format_size = g_format_size (quint64(m_total_size));
+    //Calculated by 1024 bytes
+    char *format_size = strtok(g_format_size_full(quint64(m_total_size),G_FORMAT_SIZE_IEC_UNITS),"iB");
 
     m_first_page->m_src_line->setText(uri);
     m_first_page->m_state_line->setText(tr("%1 files, %2").arg(m_total_count).arg(format_size));
@@ -248,8 +250,13 @@ void FileOperationProgressWizard::updateProgress(const QString &srcUri, const QS
     m_second_page->m_src_line->setText(srcUri);
     m_second_page->m_dest_line->setText(destUri);
 
-    char *current_format_size = g_format_size (quint64(current));
-    char *total_format_size = g_format_size(quint64(m_total_size));
+    //char *current_format_size = g_format_size (quint64(current));
+    //char *total_format_size = g_format_size(quint64(m_total_size));
+
+    //Calculated by 1024 bytes
+    char *current_format_size = strtok(g_format_size_full(quint64(current),G_FORMAT_SIZE_IEC_UNITS),"iB");
+    char *total_format_size = strtok(g_format_size_full(quint64(m_total_size),G_FORMAT_SIZE_IEC_UNITS),"iB");
+
     m_second_page->m_state_line->setText(tr("%1 done, %2 total, %3 of %4.").
                                          arg(current_format_size).arg(total_format_size)
                                          .arg(m_current_count).arg(m_total_count));

--- a/libpeony-qt/windows/format_dialog.cpp
+++ b/libpeony-qt/windows/format_dialog.cpp
@@ -47,7 +47,10 @@ Format_Dialog::Format_Dialog(const QString &m_uris,SideBarAbstractItem *m_item,Q
        quint64 total = g_file_info_get_attribute_uint64(fm_info, G_FILE_ATTRIBUTE_FILESYSTEM_SIZE);
 
        //get the rom size
-       char *total_format = g_format_size(total);
+       //char *total_format = g_format_size(total);
+
+       //Calculated by 1024 bytes
+       char *total_format = strtok(g_format_size_full(total,G_FORMAT_SIZE_IEC_UNITS),"iB");
 
        //add the rom size value into  rom_size combox
        ui->comboBox_rom_size->addItem(total_format);

--- a/src/control/tab-status-bar.cpp
+++ b/src/control/tab-status-bar.cpp
@@ -113,7 +113,12 @@ void TabStatusBar::update()
                 size += selection->size();
             }
         }
-        auto format_size = g_format_size(size);
+      
+        // auto format_size = g_format_size(size);
+    
+       //Calculated by 1024 bytes 
+        auto format_size  = g_format_size_full(size,G_FORMAT_SIZE_IEC_UNITS);
+      
         //qDebug() << "directoryCount:" <<directoryCount <<",fileCount" <<fileCount <<format_size;
 
         //in computer, only show selected count


### PR DESCRIPTION
link [22695] 电脑U盘大小和终端显示的大小不一致

修改了计算磁盘大小的方式 以1024来计算，使得终端显示的大小和查看的大小一致(四舍五入）
