### PR TITLE
slove-format-twice-canot-display-in_sidebar-And-format-error

### DIFF
--- a/peony-qt-desktop/peony-desktop-application.cpp
+++ b/peony-qt-desktop/peony-desktop-application.cpp
@@ -574,6 +574,6 @@ void PeonyDesktopApplication::volumeRemovedProcess(const std::shared_ptr<Peony::
     }
 
     //if it is possible, we stop it's drive after eject successfully.
-    if(gdrive && g_drive_can_stop(gdrive))
-        g_drive_stop(gdrive,G_MOUNT_UNMOUNT_NONE,NULL,NULL,NULL,NULL);
+   // if(gdrive && g_drive_can_stop(gdrive))
+   //     g_drive_stop(gdrive,G_MOUNT_UNMOUNT_NONE,NULL,NULL,NULL,NULL);
 };

--- a/src/control/navigation-side-bar.cpp
+++ b/src/control/navigation-side-bar.cpp
@@ -109,6 +109,9 @@ NavigationSideBar::NavigationSideBar(QWidget *parent) : QTreeView(parent)
     connect(volumeManager,&Peony::VolumeManager::driveDisconnected,this,[=](const std::shared_ptr<Peony::Drive> &drive){
         m_proxy_model->invalidate();//Multiple udisk eject display problem
     });
+        connect(volumeManager,&Peony::VolumeManager::mountAdded,this,[=](const std::shared_ptr<Peony::Mount> &mount){
+        m_proxy_model->invalidate();//display udisk in real time after format it.
+    });
 
     connect(this, &QTreeView::expanded, [=](const QModelIndex &index) {
         auto item = m_proxy_model->itemFromIndex(index);


### PR DESCRIPTION
link[25768]   peony-qt-desktop/peony-desktop-application.cpp
卸载u盘  会移除U盘导致格式化是无法检测到设备，先屏蔽等闫焕章在处理移除功能
http://172.17.66.192/biz/bug-view-25768.html

link[25425]  http://172.17.66.192/biz/bug-view-25425.html
src/control/navigation-side-bar.cpp
格式化U盘两次侧边栏无法显示问题