### PR TITLE
[FIX]  Filenames are too long to wrap automatically

### DIFF
--- a/libpeony-qt/file-operation/file-operation-progress-bar.cpp
+++ b/libpeony-qt/file-operation/file-operation-progress-bar.cpp
@@ -422,7 +422,7 @@ void MainProgressBar::paintContent(QPainter &painter)
     if (m_stopping) {
         painter.drawText(x, y, w, m_file_name_height, Qt::AlignLeft | Qt::AlignVCenter, tr("canceling ..."));
     } else {
-        painter.drawText(x, y, w, m_file_name_height, Qt::AlignLeft | Qt::AlignVCenter, m_file_name);
+        painter.drawText(x, y, w, m_file_name_height, Qt::AlignLeft | Qt::AlignVCenter | Qt::TextWordWrap | Qt::TextWrapAnywhere, m_file_name);
     }
 
     // paint percentage

--- a/libpeony-qt/file-operation/file-operation-progress-bar.h
+++ b/libpeony-qt/file-operation/file-operation-progress-bar.h
@@ -200,7 +200,7 @@ private:
     int m_icon_size = 64;
 
     // file name
-    int m_file_name_height = 20;
+    int m_file_name_height = 60;
     int m_file_name_margin = 10;
 
     // percent


### PR DESCRIPTION
[LINK] 27362

文件操作过程中，文件名太长则自动换行（最多换行显示三行）