### PR TITLE
About file operation in recent dir.

### DIFF
--- a/libpeony-qt/controls/menu/directory-view-menu/directory-view-menu.cpp
+++ b/libpeony-qt/controls/menu/directory-view-menu/directory-view-menu.cpp
@@ -538,12 +538,11 @@ const QList<QAction *> DirectoryViewMenu::constructFileOpActions()
         QString homeUri = "file://" +  QStandardPaths::writableLocation(QStandardPaths::HomeLocation);
         bool hasStandardPath = FileUtils::containsStandardPath(m_selections);
         //qDebug() << "constructFileOpActions hasStandardPath:" <<hasStandardPath;
-        if (!m_selections.isEmpty() && !m_selections.contains(homeUri) && !m_is_recent) {
+        if (!m_selections.isEmpty() && !m_selections.contains(homeUri)) {
             l<<addAction(QIcon::fromTheme("edit-copy-symbolic"), tr("&Copy"));
             connect(l.last(), &QAction::triggered, [=]() {
                 ClipboardUtils::setClipboardFiles(m_selections, false);
             });
-
             if (! hasStandardPath && !m_is_recent)
             {
                 l<<addAction(QIcon::fromTheme("edit-cut-symbolic"), tr("Cut"));

--- a/libpeony-qt/convenient-utils/clipboard-utils.cpp
+++ b/libpeony-qt/convenient-utils/clipboard-utils.cpp
@@ -29,6 +29,7 @@
 #include "file-operation-manager.h"
 #include "file-move-operation.h"
 #include "file-copy-operation.h"
+#include "file-utils.h"
 
 using namespace Peony;
 
@@ -105,10 +106,20 @@ void ClipboardUtils::setClipboardFiles(const QStringList &uris, bool isCut)
     data->setData("peony-qt/is-cut", isCutData.toByteArray());
     QList<QUrl> urls;
     QStringList encodedUris;
-    for (auto uri : uris) {
-        urls<<uri;
-        encodedUris<<uri;
+    for (QString uri : uris) {
+        if(!uri.startsWith("recent:///"))
+        {
+            urls<<uri;
+            encodedUris<<uri;
+        }
+        else
+        {
+            auto targetUri = FileUtils::getTargetUri(uri);
+            urls<<targetUri;
+            encodedUris<<targetUri;
+        }
     }
+
     data->setUrls(urls);
     QString string = encodedUris.join(" ");
     data->setData("peony-qt/encoded-uris", string.toUtf8());

--- a/libpeony-qt/file-launcher/file-launch-action.cpp
+++ b/libpeony-qt/file-launcher/file-launch-action.cpp
@@ -25,6 +25,7 @@
 
 #include "file-info.h"
 #include "file-info-job.h"
+#include "file-utils.h"
 #include "file-operation-utils.h"
 #include "audio-play-manager.h"
 
@@ -41,7 +42,11 @@ using namespace Peony;
 
 FileLaunchAction::FileLaunchAction(const QString &uri, GAppInfo *app_info, bool forceWithArg, QObject *parent) : QAction(parent)
 {
-    m_uri = uri;
+    if(uri.startsWith("recent:///"))
+        m_uri = FileUtils::getTargetUri(uri);
+    else
+        m_uri = uri;
+
     m_app_info = static_cast<GAppInfo*>(g_object_ref(app_info));
     m_force_with_arg = forceWithArg;
 

--- a/src/windows/main-window.cpp
+++ b/src/windows/main-window.cpp
@@ -573,9 +573,9 @@ void MainWindow::setShortCuts()
             if (this->getCurrentSelections().first().startsWith("trash://", Qt::CaseInsensitive)) {
                 return ;
             }
-            if (this->getCurrentSelections().first().startsWith("recent://", Qt::CaseInsensitive)) {
-                return ;
-            }
+//            if (this->getCurrentSelections().first().startsWith("recent://", Qt::CaseInsensitive)) {
+//                return ;
+//            }
         }
         Peony::ClipboardUtils::setClipboardFiles(this->getCurrentSelections(), false);
     });


### PR DESCRIPTION
[FIX]Uri problems when open file in recent dir.
Now files in recent dir can be copied correctly,besids,cut operation is banned and delete operation is aimed at the record itself.