### PR TITLE
    fix bug: the location is wrong, when drag and drop file to desktop

### DIFF
--- a/peony-qt-desktop/desktop-item-model.cpp
+++ b/peony-qt-desktop/desktop-item-model.cpp
@@ -195,12 +195,12 @@ DesktopItemModel::DesktopItemModel(QObject *parent)
 
             // aligin exsited rect
             int marginTop = notEmptyRegion.boundingRect().top();
-            while (marginTop - grid.height() > 0) {
+            while (marginTop - grid.height() >= 0) {
                 marginTop -= grid.height();
             }
 
             int marginLeft = notEmptyRegion.boundingRect().left();
-            while (marginLeft - grid.width() > 0) {
+            while (marginLeft - grid.width() >= 0) {
                 marginLeft -= grid.width();
             }
 


### PR DESCRIPTION
    bug link:http://172.17.66.192/biz/bug-view-29417.html

问题：当拖拽文件到桌面的时候，会落到第二列，而不是落在第一列
原因：处理拖拽文件坐标的时候，边界值处理不对