### PR TITLE
[FIX]  Copy the file with the same name. After closing the collision …

### DIFF
--- a/libpeony-qt/file-operation/file-copy-operation.cpp
+++ b/libpeony-qt/file-operation/file-copy-operation.cpp
@@ -280,7 +280,7 @@ fallback_retry:
                 goto fallback_retry;
             }
             case Cancel: {
-                node->setState(FileNode::Handled);
+                node->setState(FileNode::Unhandled);
                 cancel();
                 break;
             }
@@ -418,7 +418,7 @@ fallback_retry:
                 goto fallback_retry;
             }
             case Cancel: {
-                node->setState(FileNode::Handled);
+                node->setState(FileNode::Unhandled);
                 cancel();
                 break;
             }

--- a/libpeony-qt/file-operation/file-move-operation.cpp
+++ b/libpeony-qt/file-operation/file-move-operation.cpp
@@ -890,15 +890,15 @@ void FileMoveOperation::deleteRecursively(FileNode *node)
         for (auto child : *(node->children())) {
             deleteRecursively(child);
         }
-        g_file_delete(file,
-                      getCancellable().get()->get(),
-                      nullptr);
-        node->setState(FileNode::Handled);
+        if (node->state() != FileNode::Unhandled) {
+            g_file_delete(file, getCancellable().get()->get(), nullptr);
+            node->setState(FileNode::Handled);
+        }
     } else {
-        g_file_delete(file,
-                      getCancellable().get()->get(),
-                      nullptr);
-        node->setState(FileNode::Handled);
+        if (node->state() != FileNode::Unhandled) {
+            g_file_delete(file, getCancellable().get()->get(), nullptr);
+            node->setState(FileNode::Handled);
+        }
     }
     g_object_unref(file);
     qDebug()<<"deleted";

--- a/libpeony-qt/file-operation/file-node.h
+++ b/libpeony-qt/file-operation/file-node.h
@@ -163,7 +163,6 @@ public:
     void setErrorResponse(ExceptionResponse type) {
         m_err_response = type;
     }
-
     void setDestFileName(const QString &name) {
         m_dest_basename = name;
 


### PR DESCRIPTION
…popup, the file disappears

[LINK] 34062

【文件管理器】复制同名文件关闭冲突弹窗后，文件消失

第二个提交
  解决剪切文件到目标目录，文件冲突后，忽略，则源文件被删除