### PR TITLE
[FIX]  The progress bar for multiple parallel operations of large fil…

### DIFF
--- a/libpeony-qt/file-operation/file-operation-manager.cpp
+++ b/libpeony-qt/file-operation/file-operation-manager.cpp
@@ -68,9 +68,7 @@ FileOperationManager::FileOperationManager(QObject *parent) : QObject(parent)
 
     //
     connect(m_progressbar, &FileOperationProgressBar::canceled, [=] () {
-        if (!m_allow_parallel) {
-            m_progressbar->removeAllProgressbar();
-        }
+        m_progressbar->removeAllProgressbar();
     });
 }
 


### PR DESCRIPTION
…es cannot be closed

[LINK]

大文件多次粘贴操作，无法关闭进度条。

主要原因是，多次粘贴大文件，部分线程并没有开始，当全部关闭时候，没开始的线程直接退出了，没有发送 “finish” 信号，导致进度条一直在等待关闭好。
修改思路：点击全关之时，直接关闭所有未开始的进度条，然后正常关闭正在取消的线程。