### PR TITLE
[FIX]  When you drag your computer to another directory on your deskt…

### DIFF
--- a/peony-qt-desktop/desktop-icon-view.cpp
+++ b/peony-qt-desktop/desktop-icon-view.cpp
@@ -1472,6 +1472,12 @@ void DesktopIconView::dropEvent(QDropEvent *e)
         if (bmoved) {
             //move file to desktop folder
             qDebug() << "DesktopIconView move file to folder";
+            for (auto uuri : e->mimeData()->urls()) {
+                if ("trash:///" == uuri.toDisplayString() || "computer:///" == uuri.toDisplayString()) {
+                    return;
+                }
+            }
+
             m_model->dropMimeData(e->mimeData(), action, -1, -1, this->indexAt(e->pos()));
         } else {
             QListView::dropEvent(e);


### PR DESCRIPTION
…op, you should not prompt that the destination folder already contains a file of the same name

[LINK] 31249

31249 【文件管理器】在桌面将计算机拖到桌面其他目录下，不应该提示目标文件夹里已经包含同名文件，应该是权限错误

这个bug解决思路：
  当拖拽的文件中包含 computer:/// 或 trash:/// 则文件回到原处，布执行复制或移动操作