### PR TITLE
[FIX]  17814

### DIFF
--- a/libpeony-qt/bookmark-manager.cpp
+++ b/libpeony-qt/bookmark-manager.cpp
@@ -115,7 +115,7 @@ void BookMarkManager::removeBookMark(const QString &uri)
             g_usleep(100);
         }
         QUrl url = uri;
-        QString origin_path = uri;
+        QString origin_path = "favorite://" + url.path() + "?schema=" + url.scheme();
         if (m_mutex.tryLock(1000)) {
             bool successed = m_uris.contains(origin_path);
             if (successed) {


### PR DESCRIPTION
[LINK] update favorite after delete directory


17814 | 一般 | 桌面V10.1通用版 | 【文件管理器】已删除的文件夹在收藏夹不能及时更新


