### PR TITLE
Fix bugs in properties window

### DIFF
--- a/libpeony-qt/controls/property-page/basic-properties-page.h
+++ b/libpeony-qt/controls/property-page/basic-properties-page.h
@@ -106,7 +106,7 @@ protected:
      */
     QLabel *createFixedLabel(quint64 minWidth, quint64 minHeight, QString text, QWidget *parent = nullptr);
     QLabel *createFixedLabel(quint64 minWidth, quint64 minHeight, QWidget *parent = nullptr);
-    void addOpenWithMenu(QWidget *parent = nullptr);
+    void addOpenWithLayout(QWidget *parent = nullptr);
     /*!
      * 初始化第一层显示区域
      * \brief

--- a/libpeony-qt/controls/property-page/details-properties-page.cpp
+++ b/libpeony-qt/controls/property-page/details-properties-page.cpp
@@ -29,9 +29,9 @@
 #include <QtConcurrent>
 #include <QHeaderView>
 #include <QHBoxLayout>
-#include <QImage>
 #include <QImageReader>
 #include <QtNetwork/QHostInfo>
+#include "global-settings.h"
 
 using namespace Peony;
 
@@ -154,7 +154,8 @@ void DetailsPropertiesPage::initDetailsPropertiesPage()
         return;
 
     //name
-    this->addRow(tr("Name:"),m_fileInfo->displayName());
+    QString fileName =  m_tableWidget->fontMetrics().elidedText(m_fileInfo->displayName(), Qt::ElideMiddle,270);
+    this->addRow(tr("Name:"),fileName);
 
     //type
     this->addRow(tr("File type:"),m_fileInfo->fileType());
@@ -164,21 +165,9 @@ void DetailsPropertiesPage::initDetailsPropertiesPage()
     QString location = url.toDisplayString();
     if (location.startsWith("file://"))
         location = location.split("file://").last();
-    this->addRow(tr("Location:"),location);
+    location =  m_tableWidget->fontMetrics().elidedText(location, Qt::ElideMiddle,270);
 
-    //default format
-    this->setSystemTimeFormat(tr("yyyy-MM-dd, HH:mm:ss"));
-    // set time
-//    connect(GlobalSettings::getInstance(), &GlobalSettings::valueChanged, [=] (QString key) {
-//        if ("12" == key) {
-//            // 12 小时制时间
-//            this->setSysTimeFormat(tr("yyyy-MM-dd, hh:mm:ss AP"));
-//        } else if ("24" == key) {
-//            // 24 小时制时间hh:mm:ss
-//            this->setSysTimeFormat(tr("yyyy-MM-dd, HH:mm:ss"));
-//        }
-//        this->updateFileInfo(m_fileInfo.get()->uri());
-//    });
+    this->addRow(tr("Location:"),location);
 
     //createTime
     m_createDateLabel = this->createFixedLabel(0,0,"",m_tableWidget);
@@ -187,6 +176,20 @@ void DetailsPropertiesPage::initDetailsPropertiesPage()
     //modifiedTime
     m_modifyDateLabel = this->createFixedLabel(0,0,"",m_tableWidget);
     this->addRow(tr("Modify time:"),m_modifyDateLabel);
+
+    //default format
+    this->setSystemTimeFormat(tr("yyyy-MM-dd, HH:mm:ss"));
+    // set time
+    connect(GlobalSettings::getInstance(), &GlobalSettings::valueChanged, this, [=] (const QString& key) {
+        if (UKUI_CONTROL_CENTER_PANEL_PLUGIN_TIME == key) {
+            if ("12" == GlobalSettings::getInstance()->getValue(key)) {
+                setSystemTimeFormat(tr("yyyy-MM-dd, hh:mm:ss AP"));
+            } else if ("24" == GlobalSettings::getInstance()->getValue(key)) {
+                setSystemTimeFormat(tr("yyyy-MM-dd, HH:mm:ss"));
+            }
+            updateFileInfo(m_fileInfo.get()->uri());
+        }
+    });
 
     //size
     this->addRow(tr("File size:"),m_fileInfo->fileSize());

--- a/libpeony-qt/controls/property-page/permissions-properties-page.cpp
+++ b/libpeony-qt/controls/property-page/permissions-properties-page.cpp
@@ -58,12 +58,14 @@ using namespace Peony;
 PermissionsPropertiesPage::PermissionsPropertiesPage(const QStringList &uris, QWidget *parent) : PropertiesWindowTabIface(parent)
 {
     m_uri = uris.first();
-
+    QUrl url = m_uri;
     m_layout = new QVBoxLayout(this);
     m_layout->setContentsMargins(0,0,0,0);
     this->setLayout(m_layout);
 
-    m_label = new QLabel(tr("Target: %1").arg(m_uri), this);
+    m_label = new QLabel(this);
+    m_label->setText(m_label->fontMetrics().elidedText(tr("Target: %1").arg(url.path()), Qt::ElideMiddle,410));
+
     m_label->setMinimumHeight(60);
     m_label->setContentsMargins(22,0,22,0);
 
@@ -119,8 +121,8 @@ void PermissionsPropertiesPage::initTableWidget()
 void PermissionsPropertiesPage::queryPermissionsAsync(const QString &, const QString &uri)
 {
     m_uri = uri;
-    QUrl url = uri;
-    m_label->setText(tr("Target: %1").arg(url.toDisplayString()));
+    QUrl url = m_uri;
+    m_label->setText(m_label->fontMetrics().elidedText(tr("Target: %1").arg(url.toDisplayString()), Qt::ElideMiddle,410));
     m_table->setEnabled(false);
 
     GFile *file = g_file_new_for_uri(m_uri.toUtf8().constData());

--- a/libpeony-qt/controls/property-page/permissions-properties-page.cpp
+++ b/libpeony-qt/controls/property-page/permissions-properties-page.cpp
@@ -92,7 +92,7 @@ void PermissionsPropertiesPage::initTableWidget()
 {
     m_table = new QTableWidget(this);
     m_table->setRowCount(4);
-    m_table->setColumnCount(4);
+    m_table->setColumnCount(5);
     m_table->verticalHeader()->setVisible(false);
     m_table->setVerticalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
     m_table->horizontalHeader()->setFrameShape(QFrame::NoFrame);
@@ -109,7 +109,7 @@ void PermissionsPropertiesPage::initTableWidget()
     m_table->setContentsMargins(24,0,0,0);
 
     auto l = QStringList();
-    l<<tr("User or Group")<<tr("Type")<<tr("Read and Write")<<tr("Readonly");
+    l<<tr("User or Group")<<tr("Type")<<tr("Read")<<tr("Write")<<tr("Executable");
     m_table->setHorizontalHeaderLabels(l);
     m_table->setEditTriggers(QTableWidget::NoEditTriggers);
 
@@ -169,7 +169,7 @@ GAsyncReadyCallback PermissionsPropertiesPage::async_query_permisson_callback(GO
 
             bool current_user_readable = g_file_info_get_attribute_boolean(info, G_FILE_ATTRIBUTE_ACCESS_CAN_READ);
             bool current_user_writeable = g_file_info_get_attribute_boolean(info, G_FILE_ATTRIBUTE_ACCESS_CAN_WRITE);
-            bool current_user_executeable = g_file_info_get_attribute_boolean(info, G_FILE_ATTRIBUTE_ACCESS_CAN_EXECUTE);
+            bool current_user_executable = g_file_info_get_attribute_boolean(info, G_FILE_ATTRIBUTE_ACCESS_CAN_EXECUTE);
 
             bool has_unix_mode = g_file_info_has_attribute(info, G_FILE_ATTRIBUTE_UNIX_MODE);
             guint32 mode = 0;
@@ -178,33 +178,32 @@ GAsyncReadyCallback PermissionsPropertiesPage::async_query_permisson_callback(GO
 
             auto owner_readable  = mode & S_IRUSR;
             auto owner_writeable = mode & S_IWUSR;
+            auto owner_executable = mode & S_IXUSR;
 
-            //read and write
-            p_this->m_permissions[0][0] = owner_readable && owner_writeable;
-            //read only
-            p_this->m_permissions[0][1] = owner_readable && !owner_writeable;
-
-//            auto owner_executeable = mode & S_IXUSR;
-//            p_this->m_permissions[0][2] = owner_executeable;
+            //read
+            p_this->m_permissions[0][0] = owner_readable;
+            //write
+            p_this->m_permissions[0][1] = owner_writeable;
+            //executable
+            p_this->m_permissions[0][2] = owner_executable;
 
             auto group_readable  = mode & S_IRGRP;
             auto group_writeable = mode & S_IWGRP;
+            auto group_executable = mode & S_IXGRP;
 
-            p_this->m_permissions[1][0] = group_readable && group_writeable;
-            p_this->m_permissions[1][1] = group_readable && !group_writeable;
-
-//            auto group_executeable = mode & S_IXGRP;
-//            p_this->m_permissions[1][2] = group_executeable;
+            p_this->m_permissions[1][0] = group_readable;
+            p_this->m_permissions[1][1] = group_writeable;
+            p_this->m_permissions[1][2] = group_executable;
 
             auto other_readable  = mode & S_IROTH;
             auto other_writeable = mode & S_IWOTH;
+            auto other_executable = mode & S_IXOTH;
 
-            p_this->m_permissions[2][0] = other_readable && other_writeable;
-            p_this->m_permissions[2][1] = other_readable && !other_writeable;
-//            auto other_executeable = mode & S_IXOTH;
-//            p_this->m_permissions[2][2] = other_executeable;
+            p_this->m_permissions[2][0] = other_readable;
+            p_this->m_permissions[2][1] = other_writeable;
+            p_this->m_permissions[2][2] = other_executable;
 
-            qDebug()<<current_user_readable<<current_user_writeable<<current_user_executeable;
+            qDebug()<<current_user_readable<<current_user_writeable<<current_user_executable;
 
             uid_t uid = geteuid();
             struct passwd *pw = getpwuid(uid);
@@ -280,7 +279,7 @@ GAsyncReadyCallback PermissionsPropertiesPage::async_query_permisson_callback(GO
 
                 table->setItem(0, 1, itemR0C1);
 
-                for (int i = 0; i < 2; i++) {
+                for (int i = 0; i < 3; i++) {
                     table->setCellWidget(0, i + 2, nullptr);
                     QWidget *w = new QWidget(table);
                     QHBoxLayout *l = new QHBoxLayout(w);
@@ -293,14 +292,14 @@ GAsyncReadyCallback PermissionsPropertiesPage::async_query_permisson_callback(GO
 
                     switch (i) {
                     case 0:
-                        checkbox->setChecked(current_user_readable && current_user_writeable);
+                        checkbox->setChecked(current_user_readable);
                         break;
                     case 1:
-                        checkbox->setChecked(current_user_readable && !current_user_writeable);
+                        checkbox->setChecked(current_user_writeable);
                         break;
-//                    case 2:
-//                        checkbox->setChecked(current_user_executeable);
-//                        break;
+                    case 2:
+                        checkbox->setChecked(current_user_executable);
+                        break;
                     }
                 }
             }
@@ -319,9 +318,8 @@ void PermissionsPropertiesPage::changePermission(int row, int column, bool check
 {
     if(!m_enable)
         return;
-    int l_column = (column == 0 ? 1 : 0);
+
     m_permissions[row][column] = checked;
-    m_permissions[row][l_column] = !checked;
 
     this->thisPageChanged();
 
@@ -345,71 +343,51 @@ void PermissionsPropertiesPage::savePermissions()
 
     mode_t mod = 0;
     for (int i = 0; i < 3; i++) {
-        for (int j = 0; j < 2; j++) {
+        for (int j = 0; j < 3; j++) {
             bool b = m_permissions[i][j];
             if (b) {
                 int rc = i*10 + j;
                 switch (rc) {
                 case 0: {
-                    //read and write
                     mod |= S_IRUSR;
-                    mod |= S_IWUSR;
                     break;
                 }
                 case 1: {
-                    //read only
-                    mod |= S_IRUSR;
+                    mod |= S_IWUSR;
                     break;
                 }
-//                case 2: {
-//                    mod |= S_IXUSR;
-//                    break;
-//                }
+                case 2: {
+                    mod |= S_IXUSR;
+                    break;
+                }
 
                 case 10: {
                     mod |= S_IRGRP;
-                    mod |= S_IWGRP;
                     break;
                 }
                 case 11: {
-                    mod |= S_IRGRP;
+                    mod |= S_IWGRP;
                     break;
                 }
-//                case 12: {
-//                    mod |= S_IXGRP;
-//                    break;
-//                }
+                case 12: {
+                    mod |= S_IXGRP;
+                    break;
+                }
                 case 20: {
                     mod |= S_IROTH;
-                    mod |= S_IWOTH;
                     break;
                 }
                 case 21: {
-                    mod |= S_IROTH;
+                    mod |= S_IWOTH;
                     break;
                 }
-//                case 22: {
-//                    mod |= S_IXOTH;
-//                    break;
-//                }
+                case 22: {
+                    mod |= S_IXOTH;
+                    break;
+                }
                 }
             }
         }
-    }
-
-    //保存阶段，不用在意ui卡顿.
-    auto fileInfo = FileInfo::fromUri(m_uri);
-    FileInfoJob *job = new FileInfoJob(fileInfo);
-    job->setAutoDelete(true);
-    job->querySync();
-
-    //.desktop文件给予可执行
-    //.desktop在不可执行的条件下 isDesktopFile() = false
-    if (fileInfo.get()->isDesktopFile() || fileInfo.get()->displayName().endsWith(".desktop")) {
-        //FIX:可执行范围 目前只给拥有者执行权限
-        mod |= S_IXUSR;
-        //mod |= S_IXGRP;
-        //mod |= S_IXOTH;
     }
 
     QUrl url = m_uri;
@@ -434,7 +412,7 @@ void PermissionsPropertiesPage::thisPageChanged()
 void PermissionsPropertiesPage::updateCheckBox()
 {
     for (int i = 0; i < 3; i++) {
-        for (int j = 0; j < 2; j++) {
+        for (int j = 0; j < 3; j++) {
             m_table->setCellWidget(i, j + 2, nullptr);
             QWidget *w = new QWidget(m_table);
             QHBoxLayout *l = new QHBoxLayout(w);

--- a/libpeony-qt/controls/property-page/permissions-properties-page.h
+++ b/libpeony-qt/controls/property-page/permissions-properties-page.h
@@ -83,7 +83,7 @@ private:
     //防止错误修改权限
     bool m_enable = false;
 
-    bool m_permissions[3][2];
+    bool m_permissions[3][3];
 public:
     void thisPageChanged() override;
 

--- a/libpeony-qt/windows/properties-window.cpp
+++ b/libpeony-qt/windows/properties-window.cpp
@@ -137,12 +137,17 @@ PropertiesWindow::PropertiesWindow(const QStringList &uris, QWidget *parent) : Q
     m_uris.removeDuplicates();
     qDebug() << __FUNCTION__ << m_uris.count() << m_uris;
 
-    //FIX:BUG #17809
+    //FIX:BUG #31635
     if (m_uris.contains("computer:///")) {
         QtConcurrent::run([=]() {
             gotoAboutComputer();
         });
         m_uris.removeAt(m_uris.indexOf("computer:///"));
+    }
+
+    if (m_uris.count() == 0) {
+        m_destroyThis = true;
+        return;
     }
 
     if (!PropertiesWindow::checkUriIsOpen(m_uris, this)) {
@@ -330,7 +335,6 @@ bool PropertiesWindow::checkUriIsOpen(QStringList &uris, PropertiesWindow *newWi
     if (!openedPropertiesWindows)
         openedPropertiesWindows = new QList<PropertiesWindow *>();
 
-    qDebug() << "PropertiesWindow::checkUriIsOpen uri:" << uris.first();
     //1.对uris进行排序 - Sort uris
     std::sort(uris.begin(), uris.end(), [](QString a, QString b) {
         return a < b;
@@ -375,6 +379,9 @@ void PropertiesWindow::removeThisWindow(qint64 index)
         return;
 
     openedPropertiesWindows->removeAt(index);
+
+    if (openedPropertiesWindows->count() == 0)
+        delete openedPropertiesWindows;
 
 }
 

--- a/libpeony-qt/windows/properties-window.cpp
+++ b/libpeony-qt/windows/properties-window.cpp
@@ -480,14 +480,8 @@ QSize tabStyle::sizeFromContents(QStyle::ContentsType ct, const QStyleOption *op
         const QStyleOptionTab *tab = qstyleoption_cast<const QStyleOptionTab *>(opt);
         //解决按钮不能自适应的问题
         int fontWidth = tab->fontMetrics.width(tab->text);
-        if (fontWidth <= 65) {
-            //数值大于设计稿的65是因为在左侧偏移了4px
-            barSize.setWidth(70);
-        } else {
-            //同上所述
-            barSize.setWidth(fontWidth + 10);
-        }
-        //保证底部距离为设计稿上的8px
+        //宽度统一加上30px
+        barSize.setWidth(fontWidth + 30);
 
         int fontHeight = tab->fontMetrics.height();
         if (fontHeight <= 30) {


### PR DESCRIPTION
1.修改权限页面增加可执行选项。
2.修改部分ui界面
3.解决 在修改文件名同时隐藏文件导致的错误。
4.使用Elide方法一些超长路径和文件名。
5.修复在peony中右键计算机打开属性窗口导致peony崩溃的问题。