### PR TITLE
[FIX]  There are multiple files in the page. List mode uses the down …

### DIFF
--- a/libpeony-qt/controls/directory-view/view/list-view/list-view.cpp
+++ b/libpeony-qt/controls/directory-view/view/list-view/list-view.cpp
@@ -102,8 +102,8 @@ void ListView::scrollTo(const QModelIndex &index, QAbstractItemView::ScrollHint 
     // the fast keyboard locating of default tree view will be disabled
     // due to the function is overrided, too.
 
-    //QTreeView::scrollTo(index, hint);
-    //updateGeometries();
+    QTreeView::scrollTo(index, hint);
+//    updateGeometries();
 }
 
 bool ListView::isDragging()
@@ -411,22 +411,22 @@ void ListView::resizeEvent(QResizeEvent *e)
     }
 }
 
-void ListView::updateGeometries()
-{
-    QTreeView::updateGeometries();
-    if (!model())
-        return;
+//void ListView::updateGeometries()
+//{
+//    QTreeView::updateGeometries();
+//    if (!model())
+//        return;
 
-    if (model()->columnCount() == 0 || model()->rowCount() == 0)
-        return;
+//    if (model()->columnCount() == 0 || model()->rowCount() == 0)
+//        return;
 
-    header()->setFixedWidth(this->width());
+//    header()->setFixedWidth(this->width());
 
-    QStyleOptionViewItem opt = viewOptions();
-    int height = itemDelegate()->sizeHint(opt, QModelIndex()).height();
-    verticalScrollBar()->setMaximum(verticalScrollBar()->maximum() + 2);
-    //setViewportMargins(0, header()->height(), 0, height);
-}
+//    QStyleOptionViewItem opt = viewOptions();
+//    int height = itemDelegate()->sizeHint(opt, QModelIndex()).height();
+//    verticalScrollBar()->setMaximum(verticalScrollBar()->maximum() + 2);
+//    //setViewportMargins(0, header()->height(), 0, height);
+//}
 
 void ListView::wheelEvent(QWheelEvent *e)
 {
@@ -587,6 +587,7 @@ QRect ListView::visualRect(const QModelIndex &index) const
 //    if (index.column() == 0) {
 //        rect.setX(0);
 //    }
+
     return rect;
 }
 

--- a/libpeony-qt/controls/directory-view/view/list-view/list-view.h
+++ b/libpeony-qt/controls/directory-view/view/list-view/list-view.h
@@ -126,7 +126,7 @@ protected:
 
     void resizeEvent(QResizeEvent *e) override;
 
-    void updateGeometries() override;
+//    void updateGeometries() override;
 
     void wheelEvent (QWheelEvent *e) override;
 

--- a/libpeony-qt/file-operation/file-rename-operation.cpp
+++ b/libpeony-qt/file-operation/file-rename-operation.cpp
@@ -343,23 +343,23 @@ cancel:
     if (src_first_mount) {
         needSync = g_mount_can_unmount(src_first_mount);
         g_object_unref(src_first_mount);
-    } else {
+    } /*else {
         // maybe a vfs file.
+        // root filesystem
         needSync = true;
-    }
+    }*/
     g_object_unref(src_first_file);
 
+    GError* err = NULL;
     GFile *dest_dir_file = g_file_new_for_uri(destUri.toUtf8().constData());
-    GMount *dest_dir_mount = g_file_find_enclosing_mount(dest_dir_file, nullptr, nullptr);
-    if (src_first_mount) {
+    GMount *dest_dir_mount = g_file_find_enclosing_mount(dest_dir_file, nullptr, &err);
+    if (dest_dir_mount) {
         needSync = g_mount_can_unmount(dest_dir_mount);
         g_object_unref(dest_dir_mount);
-    } else {
+    } /*else {
         needSync = true;
-    }
+    }*/
     g_object_unref(dest_dir_file);
-
-    //needSync = true;
 
     if (needSync) {
         char *path = g_file_get_path(dest_dir_file);

--- a/src/control/navigation-side-bar.cpp
+++ b/src/control/navigation-side-bar.cpp
@@ -258,7 +258,9 @@ void NavigationSideBar::resizeEvent(QResizeEvent *e)
 
 void NavigationSideBar::dropEvent(QDropEvent *e)
 {
-    if (dropIndicatorPosition() == QAbstractItemView::AboveItem || dropIndicatorPosition() == QAbstractItemView::BelowItem) {
+    QString destUri = m_proxy_model->itemFromIndex(indexAt(e->pos()))->uri();
+
+    if (dropIndicatorPosition() == QAbstractItemView::AboveItem || dropIndicatorPosition() == QAbstractItemView::BelowItem || "favorite:///" == destUri) {
         // add to bookmark
         e->setAccepted(true);
 
@@ -278,6 +280,7 @@ void NavigationSideBar::dropEvent(QDropEvent *e)
             }
         }
     }
+
     QTreeView::dropEvent(e);
 }
 


### PR DESCRIPTION
…key to go down,and the progress bar does not follow.

[LINK] 33466

1. 列表模式下，视图框无法随着方向键改变而改变，导致无法看到选中的文件
2. 无法删除收藏夹中的文件夹
3. 无法拖拽文件到收藏夹中
4. 制作启动盘的时候，桌面无重命名触发 sync 操作，弹出进度框。主要原因是根文件系统中使用 g_file_find_enclosing_mount 调用返回空指针，而u盘等可移动设备才会返回 GMount