### PR TITLE
fix some bugs on Properties window

### DIFF
--- a/libpeony-qt/controls/property-page/basic-properties-page-factory.cpp
+++ b/libpeony-qt/controls/property-page/basic-properties-page-factory.cpp
@@ -54,7 +54,7 @@ bool BasicPropertiesPageFactory::supportUris(const QStringList &uris)
         return false;
 
     for (auto uri : uris) {
-        if (uri.startsWith("computer://"))
+        if (uri.startsWith("computer://") || uri.startsWith("trash://") || uri.startsWith("recent://"))
             return false;
     }
 

--- a/libpeony-qt/controls/property-page/basic-properties-page.h
+++ b/libpeony-qt/controls/property-page/basic-properties-page.h
@@ -31,6 +31,7 @@
 #include <QGridLayout>
 #include <QThread>
 #include <memory>
+#include <QtConcurrent>
 
 #include "properties-window-tab-iface.h"
 #include "open-with-properties-page.h"
@@ -86,6 +87,7 @@ public:
 
     explicit BasicPropertiesPage(const QStringList &uris, QWidget *parent = nullptr);
     ~BasicPropertiesPage();
+    void init();
 
 
     // PropertiesWindowTabIface interface
@@ -106,7 +108,7 @@ protected:
      */
     QLabel *createFixedLabel(quint64 minWidth, quint64 minHeight, QString text, QWidget *parent = nullptr);
     QLabel *createFixedLabel(quint64 minWidth, quint64 minHeight, QWidget *parent = nullptr);
-    void addOpenWithMenu(QWidget *parent = nullptr);
+    void addOpenWithLayout(QWidget *parent = nullptr);
     /*!
      * 初始化第一层显示区域
      * \brief
@@ -126,24 +128,19 @@ protected:
     }
 
 protected Q_SLOTS:
-    void getFIleInfo(const QStringList &uris);
+    void getFIleInfo(QString uri);
     void onSingleFileChanged(const QString &oldUri, const QString &newUri);
     void countFilesAsync(const QStringList &uris);
     void onFileCountOne(const QString &uri, quint64 size);
     void cancelCount();
 
     void updateInfo(const QString &uri);
-    /*!
-     * 当前页面发生改变
-     * \brief
-     */
-    void thisPageChanged() {
-        this->m_thisPageChanged = true;
-    }
 
 private:
     QVBoxLayout                 *m_layout = nullptr;
     std::shared_ptr<FileInfo>    m_info   = nullptr;
+    QStringList                  m_uris;
+//    QFutureWatcher<void>        *m_futureWatcher = nullptr;
     std::shared_ptr<FileWatcher> m_watcher;
     std::shared_ptr<FileWatcher> m_thumbnail_watcher;
 

--- a/libpeony-qt/controls/property-page/open-with-properties-page-factory.cpp
+++ b/libpeony-qt/controls/property-page/open-with-properties-page-factory.cpp
@@ -62,7 +62,7 @@ bool OpenWithPropertiesPageFactory::supportUris(const QStringList &uris)
     job->setAutoDelete(true);
     job->querySync();
 
-    if (fileInfo.get()->isDir() || fileInfo.get()->isDesktopFile() || fileInfo.get()->isVolume() || fileInfo.get()->isVirtual() || fileInfo->canExecute())
+    if (fileInfo.get()->isDir() || fileInfo.get()->isDesktopFile() || fileInfo.get()->isVolume() || fileInfo.get()->isVirtual() || fileInfo->isSymbolLink())
         return false;
 
     return true;

--- a/libpeony-qt/controls/property-page/open-with-properties-page.h
+++ b/libpeony-qt/controls/property-page/open-with-properties-page.h
@@ -34,16 +34,20 @@
 #include <QDebug>
 #include <QDialog>
 #include <QDialogButtonBox>
+#include <QtConcurrent>
 
 namespace Peony {
 
 class LaunchHashList {
 public:
+    static LaunchHashList *getAllLaunchHashList(const QString &uri, QWidget *parent = nullptr);
+    LaunchHashList();
     LaunchHashList(const QString &uri, QWidget *parent = nullptr);
+    ~LaunchHashList();
 public:
-    //保存该文件的全部打开方式
+    //保存该文件的全部打开方式 - Save all open methods of the file
     QListWidget *m_actionList = nullptr;
-    //每个listItem对应的launchAction
+    //每个listItem对应的launchAction - Launch Action corresponding to each list Item
     QHash<QListWidgetItem*,FileLaunchAction*> *m_actionHash = nullptr;
 };
 
@@ -54,6 +58,23 @@ public:
     explicit NewFileLaunchDialog(const QString &uri, QWidget *parent = nullptr);
 
     virtual ~NewFileLaunchDialog();
+
+    QSize sizeHint() const override {
+        return QSize(400, 600);
+    }
+private:
+    QVBoxLayout      *m_layout     = nullptr;
+    QDialogButtonBox *m_button_box = nullptr;
+    LaunchHashList *m_launchHashList = nullptr;
+};
+
+class AllFileLaunchDialog : public QDialog
+{
+Q_OBJECT
+public:
+    explicit AllFileLaunchDialog(const QString &uri, QWidget *parent = nullptr);
+
+    virtual ~AllFileLaunchDialog();
 
     QSize sizeHint() const override {
         return QSize(400, 600);
@@ -102,11 +123,14 @@ public:
     explicit OpenWithPropertiesPage(const QString &uri, QWidget *parent = nullptr);
     ~OpenWithPropertiesPage();
 
+    void init();
     void saveAllChange() override;
 
 private:
     QVBoxLayout *m_layout = nullptr;
+
     std::shared_ptr<FileInfo> m_fileInfo  = nullptr;
+    QFutureWatcher<void> *m_futureWatcher = nullptr;
     //新的打开方式
     FileLaunchAction *m_newAction      = nullptr;
     LaunchHashList   *m_launchHashList = nullptr;

--- a/libpeony-qt/controls/property-page/permissions-properties-page.h
+++ b/libpeony-qt/controls/property-page/permissions-properties-page.h
@@ -83,7 +83,7 @@ private:
     //防止错误修改权限
     bool m_enable = false;
 
-    bool m_permissions[3][2];
+    bool m_permissions[3][3];
 public:
     void thisPageChanged() override;
 

--- a/libpeony-qt/controls/property-page/recent-and-trash-properties-page.cpp
+++ b/libpeony-qt/controls/property-page/recent-and-trash-properties-page.cpp
@@ -32,64 +32,118 @@
 #include <QUrl>
 
 using namespace Peony;
+//460 - 16 - 16 = 428
+#define FIXED_ROW_WIDTH 428;
 
 RecentAndTrashPropertiesPage::RecentAndTrashPropertiesPage(const QStringList &uris, QWidget *parent) : PropertiesWindowTabIface(parent)
 {
     m_uri = uris.first();
-    bool startWithTrash = m_uri.startsWith("trash:///");
 
-    //FIXME: replace BLOCKING api in ui thread.
-    auto info = FileInfo::fromUri(m_uri);
-    if (info->displayName().isEmpty()) {
-        FileInfoJob job(info);
-        job.querySync();
+    QFuture<void> future = QtConcurrent::run([=]() {
+        m_fileInfo = FileInfo::fromUri(m_uri);
+        if (m_fileInfo->displayName().isEmpty()) {
+            FileInfoJob job(m_fileInfo);
+            job.querySync();
+        }
+    });
+
+    m_futureWatcher = new QFutureWatcher<void>();
+    m_futureWatcher->setFuture(future);
+
+    connect(m_futureWatcher,&QFutureWatcher<void>::finished,this,&RecentAndTrashPropertiesPage::init);
+}
+
+void RecentAndTrashPropertiesPage::init()
+{
+    if (m_futureWatcher) {
+        delete m_futureWatcher;
+        m_futureWatcher = nullptr;
     }
-
     m_layout = new QFormLayout(this);
     m_layout->setRowWrapPolicy(QFormLayout::WrapLongRows);
     m_layout->setFormAlignment(Qt::AlignLeft|Qt::AlignHCenter);
     m_layout->setLabelAlignment(Qt::AlignRight|Qt::AlignHCenter);
+    m_layout->setContentsMargins(16,16,16,0);
+    this->setLayout(m_layout);
 
-    auto icon = new QPushButton(QIcon::fromTheme(info->iconName()), nullptr, this);
+    auto icon = new QPushButton(QIcon::fromTheme(m_fileInfo->iconName()), nullptr, this);
     icon->setIconSize(QSize(48, 48));
     icon->setProperty("isIcon", true);
+
+    QVBoxLayout *boxLayout = new QVBoxLayout(this);
     auto name = new QLineEdit(this);
     name->setReadOnly(true);
-    name->setText(info->displayName());
-    m_layout->addRow(icon, name);
-    m_layout->setAlignment(name, Qt::AlignLeft|Qt::AlignCenter);
+    name->setText(m_fileInfo->displayName());
+
+    boxLayout->addWidget(name);
+    boxLayout->setAlignment(Qt::AlignBottom);
+
+    m_layout->addRow(icon, boxLayout);
+    m_layout->setAlignment(Qt::AlignCenter);
 
     addSeparator();
+
+    bool startWithTrash = m_uri.startsWith("trash:///");
 
     if (startWithTrash) {
         if (m_uri == "trash:///") {
 
         } else {
-            GFile *file = g_file_new_for_uri(m_uri.toUtf8().constData());
-            GFileInfo *info = g_file_query_info(file,
-                                                G_FILE_ATTRIBUTE_TRASH_ORIG_PATH,
-                                                G_FILE_QUERY_INFO_NOFOLLOW_SYMLINKS,
-                                                nullptr,
-                                                nullptr);
-            auto origin_path = g_file_info_get_attribute_byte_string(info, G_FILE_ATTRIBUTE_TRASH_ORIG_PATH);
+            QLabel *label =new QLabel(this);
+            QFuture<void> future = QtConcurrent::run([=]() {
+                GFile *file = g_file_new_for_uri(m_uri.toUtf8().constData());
+                GFileInfo *info = g_file_query_info(file,
+                                                    G_FILE_ATTRIBUTE_TRASH_ORIG_PATH,
+                                                    G_FILE_QUERY_INFO_NOFOLLOW_SYMLINKS,
+                                                    nullptr,
+                                                    nullptr);
+                auto origin_path = g_file_info_get_attribute_byte_string(info, G_FILE_ATTRIBUTE_TRASH_ORIG_PATH);
 
-            auto label = new QLabel(QString(origin_path), this);
-            label->setWordWrap(true);
-            m_layout->addRow(tr("Origin Path: "), label);
+                QUrl url(FileUtils::getParentUri("file://" + QString(origin_path)));
 
-            g_object_unref(info);
-            g_object_unref(file);
+                quint64 width = FIXED_ROW_WIDTH - label->fontMetrics().width(tr("Origin Path: "));
+                label->setText(label->fontMetrics().elidedText(url.path(), Qt::ElideMiddle,width));
+                label->setWordWrap(true);
+
+                g_object_unref(info);
+                g_object_unref(file);
+            });
+
+            m_futureWatcher = new QFutureWatcher<void>();
+            m_futureWatcher->setFuture(future);
+
+            connect(m_futureWatcher,&QFutureWatcher<void>::finished,this,[=]() {
+                m_layout->addRow(tr("Origin Path: "), label);
+
+                if (m_futureWatcher)
+                    delete m_futureWatcher;
+            });
         }
     } else {
         if (m_uri == "recent:///") {
 
         } else {
-            //FIXME: replace BLOCKING api in ui thread.
-            auto targetUri = FileUtils::getTargetUri(m_uri);
-            auto label = new QLabel(QUrl(targetUri).toDisplayString(), this);
-            label->setWordWrap(true);
-            m_layout->addRow(tr("Size: "), new QLabel(info->fileSize(), this));
-            m_layout->addRow(tr("Original Location: "), label);
+            QLabel *sizeLabel =new QLabel(this);
+            QLabel *locationLabel =new QLabel(this);
+            QFuture<void> future = QtConcurrent::run([=]() {
+                auto targetUri = FileUtils::getTargetUri(m_uri);
+                quint64 width = FIXED_ROW_WIDTH - locationLabel->fontMetrics().width(tr("Original Location: "));
+                locationLabel->setText(locationLabel->fontMetrics().elidedText(QUrl(targetUri).toDisplayString(), Qt::ElideMiddle,width));
+                locationLabel->setWordWrap(true);
+
+                sizeLabel->setText(m_fileInfo->fileSize());
+            });
+
+            m_futureWatcher = new QFutureWatcher<void>();
+            m_futureWatcher->setFuture(future);
+
+            connect(m_futureWatcher,&QFutureWatcher<void>::finished,this,[=]() {
+                m_layout->addRow(tr("Size: "), sizeLabel);
+                m_layout->addRow(tr("Original Location: "), locationLabel);
+
+                if (m_futureWatcher)
+                    delete m_futureWatcher;
+            });
         }
     }
 }

--- a/libpeony-qt/controls/property-page/recent-and-trash-properties-page.h
+++ b/libpeony-qt/controls/property-page/recent-and-trash-properties-page.h
@@ -24,7 +24,9 @@
 #define RECENTANDTRASHPROPERTIESPAGE_H
 
 #include <QWidget>
+#include <QtConcurrent>
 
+#include "file-info.h"
 #include "properties-window-tab-iface.h"
 #include "peony-core_global.h"
 
@@ -40,10 +42,13 @@ public:
 
 protected:
     void addSeparator();
+    void init();
 
 private:
     QString m_uri;
     QFormLayout *m_layout;
+    std::shared_ptr<FileInfo> m_fileInfo = nullptr;
+    QFutureWatcher<void> *m_futureWatcher = nullptr;
 
     // PropertiesWindowTabIface interface
 public:

--- a/libpeony-qt/windows/properties-window.cpp
+++ b/libpeony-qt/windows/properties-window.cpp
@@ -137,12 +137,17 @@ PropertiesWindow::PropertiesWindow(const QStringList &uris, QWidget *parent) : Q
     m_uris.removeDuplicates();
     qDebug() << __FUNCTION__ << m_uris.count() << m_uris;
 
-    //FIX:BUG #17809
+    //FIX:BUG #31635
     if (m_uris.contains("computer:///")) {
         QtConcurrent::run([=]() {
             gotoAboutComputer();
         });
         m_uris.removeAt(m_uris.indexOf("computer:///"));
+    }
+
+    if (m_uris.count() == 0) {
+        m_destroyThis = true;
+        return;
     }
 
     if (!PropertiesWindow::checkUriIsOpen(m_uris, this)) {
@@ -327,10 +332,10 @@ void PropertiesWindow::initTabPage(const QStringList &uris)
 
 bool PropertiesWindow::checkUriIsOpen(QStringList &uris, PropertiesWindow *newWindow)
 {
-    if (!openedPropertiesWindows)
+    if (!openedPropertiesWindows) {
         openedPropertiesWindows = new QList<PropertiesWindow *>();
-
-    qDebug() << "PropertiesWindow::checkUriIsOpen uri:" << uris.first();
+        qDebug() << __FILE__ << __FUNCTION__ << "new->openedPropertiesWindows";
+    }
     //1.对uris进行排序 - Sort uris
     std::sort(uris.begin(), uris.end(), [](QString a, QString b) {
         return a < b;
@@ -375,6 +380,12 @@ void PropertiesWindow::removeThisWindow(qint64 index)
         return;
 
     openedPropertiesWindows->removeAt(index);
+
+    if (openedPropertiesWindows->count() == 0) {
+        delete openedPropertiesWindows;
+        openedPropertiesWindows = nullptr;
+        qDebug() << __FILE__ << __FUNCTION__ << "delete->openedPropertiesWindows";
+    }
 
 }
 
@@ -480,14 +491,8 @@ QSize tabStyle::sizeFromContents(QStyle::ContentsType ct, const QStyleOption *op
         const QStyleOptionTab *tab = qstyleoption_cast<const QStyleOptionTab *>(opt);
         //解决按钮不能自适应的问题
         int fontWidth = tab->fontMetrics.width(tab->text);
-        if (fontWidth <= 65) {
-            //数值大于设计稿的65是因为在左侧偏移了4px
-            barSize.setWidth(70);
-        } else {
-            //同上所述
-            barSize.setWidth(fontWidth + 10);
-        }
-        //保证底部距离为设计稿上的8px
+        //宽度统一加上30px
+        barSize.setWidth(fontWidth + 30);
 
         int fontHeight = tab->fontMetrics.height();
         if (fontHeight <= 30) {
@@ -497,8 +502,8 @@ QSize tabStyle::sizeFromContents(QStyle::ContentsType ct, const QStyleOption *op
             //同上所述
             barSize.setHeight(fontHeight + 12);
         }
-        qDebug() << "tabStyle::sizeFromContents font width:" << fontWidth << "height:" << fontHeight << "text:"
-                 << tab->text;
+//        qDebug() << "tabStyle::sizeFromContents font width:" << fontWidth << "height:" << fontHeight << "text:"
+//                 << tab->text;
     }
 
     return barSize;


### PR DESCRIPTION
1.修改basic页部分UI。
2.在不可修改名称的文件夹上屏蔽隐藏按钮，改名框和移动按钮。
3.修复在同时改名和隐藏文件的情况下peony崩溃的问题。
4.修复在peony中右键计算机打开属性窗口时窗口崩溃的问题。
5.增加日期格式跟随系统改变。
6.使用elide方式处理部分文字。
7.权限页添加可执行选项

open With tab 页
1.增加选择其他打开方式功能。
2.加入多线程支持。
3.更新翻译。

修复：#37619 
