### PR TITLE
DesktopIconView: reimplement startDrag() method.

### DIFF
--- a/libpeony-qt/controls/directory-view/view/icon-view/icon-view.cpp
+++ b/libpeony-qt/controls/directory-view/view/icon-view/icon-view.cpp
@@ -271,6 +271,10 @@ void IconView::dropEvent(QDropEvent *e)
             auto uri = m_sort_filter_proxy_model->itemFromIndex(proxy_index)->uri();
             if(!e->mimeData()->urls().contains(uri))
                 m_model->dropMimeData(e->mimeData(), action, 0, 0, index);
+        } else {
+            if (m_ctrl_key_pressed) {
+                m_model->dropMimeData(e->mimeData(), Qt::CopyAction, 0, 0, QModelIndex());
+            }
         }
         return;
     }

--- a/libpeony-qt/controls/directory-view/view/list-view/list-view.cpp
+++ b/libpeony-qt/controls/directory-view/view/list-view/list-view.cpp
@@ -395,6 +395,10 @@ void ListView::dropEvent(QDropEvent *e)
             auto uri = m_proxy_model->itemFromIndex(proxy_index)->uri();
             if(!e->mimeData()->urls().contains(uri))
                 m_model->dropMimeData(e->mimeData(), action, 0, 0, index);
+        } else {
+            if (m_ctrl_key_pressed) {
+                m_model->dropMimeData(e->mimeData(), Qt::CopyAction, 0, 0, QModelIndex());
+            }
         }
         return;
     }

--- a/libpeony-qt/model/file-item-model.cpp
+++ b/libpeony-qt/model/file-item-model.cpp
@@ -442,6 +442,11 @@ Qt::DropActions FileItemModel::supportedDropActions() const
     return Qt::MoveAction|Qt::CopyAction;
 }
 
+Qt::DropActions FileItemModel::supportedDragActions() const
+{
+    return Qt::MoveAction;
+}
+
 bool FileItemModel::dropMimeData(const QMimeData *data, Qt::DropAction action, int row, int column, const QModelIndex &parent)
 {
     qDebug()<<"drop mime data";

--- a/libpeony-qt/model/file-item-model.h
+++ b/libpeony-qt/model/file-item-model.h
@@ -206,6 +206,7 @@ public:
                       int row, int column, const QModelIndex &parent) override;
 
     Qt::DropActions supportedDropActions() const override;
+    Qt::DropActions supportedDragActions() const override;
 
 Q_SIGNALS:
     /*!

--- a/libpeony-qt/model/side-bar-model.cpp
+++ b/libpeony-qt/model/side-bar-model.cpp
@@ -404,5 +404,11 @@ bool SideBarModel::dropMimeData(const QMimeData *data, Qt::DropAction action, in
 
 Qt::DropActions SideBarModel::supportedDropActions() const
 {
+    return Qt::MoveAction|Qt::CopyAction;
     return Qt::MoveAction|Qt::CopyAction|Qt::LinkAction;
+}
+
+Qt::DropActions SideBarModel::supportedDragActions() const
+{
+    return Qt::MoveAction;
 }

--- a/libpeony-qt/model/side-bar-model.h
+++ b/libpeony-qt/model/side-bar-model.h
@@ -92,6 +92,7 @@ public:
                       int row, int column, const QModelIndex &parent) override;
 
     Qt::DropActions supportedDropActions() const override;
+    Qt::DropActions supportedDragActions() const override;
 
 Q_SIGNALS:
     void indexUpdated(const QModelIndex &index);

--- a/peony-qt-desktop/desktop-icon-view.cpp
+++ b/peony-qt-desktop/desktop-icon-view.cpp
@@ -76,6 +76,11 @@
 #include <QToolTip>
 #include <QGSettings>
 
+#include <QDrag>
+#include <QMimeData>
+#include <QPixmap>
+#include <QPainter>
+
 using namespace Peony;
 
 #define ITEM_POS_ATTRIBUTE "metadata::peony-qt-desktop-item-position"
@@ -1355,8 +1360,14 @@ void DesktopIconView::setEditFlag(bool edit)
 
 void DesktopIconView::mousePressEvent(QMouseEvent *e)
 {
+    m_press_pos = e->pos();
     // bug extend selection bug
     m_real_do_edit = false;
+
+    if (e->modifiers() && Qt::ControlModifier)
+        m_ctrl_key_pressed = true;
+    else
+        m_ctrl_key_pressed = false;
 
     if (!m_ctrl_or_shift_pressed) {
         if (!indexAt(e->pos()).isValid()) {
@@ -1423,16 +1434,13 @@ void DesktopIconView::mouseDoubleClickEvent(QMouseEvent *event)
 void DesktopIconView::dragEnterEvent(QDragEnterEvent *e)
 {
     m_real_do_edit = false;
-    if (e->keyboardModifiers() && Qt::ControlModifier)
-        m_ctrl_key_pressed = true;
-    else
-        m_ctrl_key_pressed = false;
 
     auto action = m_ctrl_key_pressed ? Qt::CopyAction : Qt::MoveAction;
     qDebug()<<"drag enter event" <<action;
     if (e->mimeData()->hasUrls()) {
         e->setDropAction(action);
-        e->acceptProposedAction();
+        e->accept();
+        //e->acceptProposedAction();
     }
 
     if (e->source() == this) {
@@ -1645,6 +1653,52 @@ void DesktopIconView::dropEvent(QDropEvent *e)
     }
     m_model->dropMimeData(e->mimeData(), action, -1, -1, this->indexAt(e->pos()));
     //FIXME: save item position
+}
+
+void DesktopIconView::startDrag(Qt::DropActions supportedActions)
+{
+    auto indexes = selectedIndexes();
+    if (indexes.count() > 0) {
+        auto pos = mapFromGlobal(QCursor::pos());
+        qreal scale = 1.0;
+        QWidget *window = this->window();
+        if (window) {
+            auto windowHandle = window->windowHandle();
+            if (windowHandle) {
+                scale = windowHandle->devicePixelRatio();
+            }
+        }
+
+        auto drag = new QDrag(this);
+        drag->setMimeData(model()->mimeData(indexes));
+
+        QRegion rect;
+        QHash<QModelIndex, QRect> indexRectHash;
+        for (auto index : indexes) {
+            rect += (visualRect(index));
+            indexRectHash.insert(index, visualRect(index));
+        }
+
+        QRect realRect = rect.boundingRect();
+        QPixmap pixmap(realRect.size() * scale);
+        pixmap.fill(Qt::transparent);
+        pixmap.setDevicePixelRatio(scale);
+        QPainter painter(&pixmap);
+        for (auto index : indexes) {
+            painter.save();
+            painter.translate(indexRectHash.value(index).topLeft() - rect.boundingRect().topLeft());
+            itemDelegate()->paint(&painter, viewOptions(), index);
+            painter.restore();
+        }
+
+        drag->setPixmap(pixmap);
+        drag->setHotSpot(pos - rect.boundingRect().topLeft());
+        drag->setDragCursor(QPixmap(), m_ctrl_key_pressed? Qt::CopyAction: Qt::MoveAction);
+        drag->exec(m_ctrl_key_pressed? Qt::CopyAction: Qt::MoveAction);
+
+    } else {
+        return QListView::startDrag(Qt::MoveAction|Qt::CopyAction);
+    }
 }
 
 const QFont DesktopIconView::getViewItemFont(QStyleOptionViewItem *item)

--- a/peony-qt-desktop/desktop-icon-view.h
+++ b/peony-qt-desktop/desktop-icon-view.h
@@ -196,6 +196,8 @@ protected:
     void dragMoveEvent(QDragMoveEvent *e);
     void dropEvent(QDropEvent *e);
 
+    void startDrag(Qt::DropActions supportedActions);
+
     void wheelEvent(QWheelEvent *e);
     void keyPressEvent(QKeyEvent *e);
     void keyReleaseEvent(QKeyEvent *e);
@@ -248,6 +250,8 @@ private:
     QMap<QScreen*, bool> m_screens;
     PeonyDbusService *m_peonyDbusSer;
     QMap<QString, QRect> m_item_rect_hash;
+
+    QPoint m_press_pos;
 };
 
 }

--- a/peony-qt-desktop/desktop-item-model.cpp
+++ b/peony-qt-desktop/desktop-item-model.cpp
@@ -713,8 +713,13 @@ bool DesktopItemModel::dropMimeData(const QMimeData *data, Qt::DropAction action
 
 Qt::DropActions DesktopItemModel::supportedDropActions() const
 {
-    //return Qt::MoveAction|Qt::CopyAction;
+    return Qt::MoveAction|Qt::CopyAction;
     return QAbstractItemModel::supportedDropActions();
+}
+
+Qt::DropActions DesktopItemModel::supportedDragActions() const
+{
+    return Qt::MoveAction;
 }
 
 void DesktopItemModel::refresh()

--- a/peony-qt-desktop/desktop-item-model.h
+++ b/peony-qt-desktop/desktop-item-model.h
@@ -72,6 +72,7 @@ public:
                       int row, int column, const QModelIndex &parent) override;
 
     Qt::DropActions supportedDropActions() const override;
+    Qt::DropActions supportedDragActions() const override;
 
 Q_SIGNALS:
     void requestLayoutNewItem(const QString &uri);

--- a/src/control/navigation-side-bar.cpp
+++ b/src/control/navigation-side-bar.cpp
@@ -281,6 +281,12 @@ void NavigationSideBar::dropEvent(QDropEvent *e)
         }
     }
 
+    if (e->keyboardModifiers() == Qt::ControlModifier) {
+        m_model->dropMimeData(e->mimeData(), Qt::CopyAction, 0, 0, QModelIndex());
+        e->accept();
+        return;
+    }
+
     QTreeView::dropEvent(e);
 }
 


### PR DESCRIPTION
models: change default drag and drop action as move action.

note that qt asumes copy action as default drop action in model/view desgin. that let the dnd action is offen misunterstanded by people.
so we reimplement it in peony. link to #25917.