### PR TITLE
[FIX]  Files named with special characters cannot link shortcuts to t…

### DIFF
--- a/libpeony-qt/file-operation/file-link-operation.cpp
+++ b/libpeony-qt/file-operation/file-link-operation.cpp
@@ -42,6 +42,8 @@ FileLinkOperation::FileLinkOperation(QString srcUri, QString destDirUri, QObject
         m_dest_uri = destDirUri + "/" + tr("Symbolic Link") + " - " + url.fileName();
     }
 
+    m_dest_uri = QUrl::fromEncoded(m_dest_uri.toUtf8()).toDisplayString();
+
     QStringList fake_uris;
     fake_uris<<srcUri;
     m_info = std::make_shared<FileOperationInfo>(fake_uris, destDirUri, FileOperationInfo::Link);


### PR DESCRIPTION
…he desktop

[LINK] 32325

32325 【文件管理器】特殊字符命名的文件无法链接快捷方式到桌面