### PR TITLE
[FIX]  Copy file name with time to USB drive, copy failed

### DIFF
--- a/libpeony-qt/file-info-job.h
+++ b/libpeony-qt/file-info-job.h
@@ -123,7 +123,8 @@ protected:
             FileInfoJob *thisJob);
 
 private:
-    void refreshInfoContents(GFileInfo *new_info);
+    void refreshFileSystemInfo (GFileInfo* new_info);
+    void refreshInfoContents (GFileInfo *new_info);
     std::shared_ptr<FileInfo> m_info;
 
     quint64 m_file_size_uint = 0;
@@ -137,6 +138,7 @@ private:
     bool m_auto_delete = false;
 
     GCancellable *m_cancellable = nullptr;
+    GCancellable *m_fs_cancellable = nullptr;
 };
 
 }

--- a/libpeony-qt/file-info.h
+++ b/libpeony-qt/file-info.h
@@ -201,6 +201,11 @@ public:
     QString type() {
         return m_content_type;
     }
+
+    QString fileSystemType() {
+        return m_fs_type;
+    }
+
     quint64 size() {
         return m_size;
     }
@@ -372,6 +377,9 @@ private:
 
     QString m_target_uri;
     QString m_symlink_target;
+
+    // filesystem
+    QString m_fs_type;
 
     /*!
      * \brief m_cancellable

--- a/libpeony-qt/file-operation/file-operation.h
+++ b/libpeony-qt/file-operation/file-operation.h
@@ -299,6 +299,7 @@ public Q_SLOTS:
 
 protected:
     void fileSync (QString srcFile, QString destFile);
+    bool makeFileNameValidForDestFS (QString& srcPath, QString& destPath, QString* newFileName);
 
     GCancellableWrapperPtr getCancellable() {
         return m_cancellable_wrapper;
@@ -311,10 +312,10 @@ protected:
     void notifyFileWatcherOperationFinished();
 
 private:
-    GCancellableWrapperPtr m_cancellable_wrapper = nullptr;
-    bool m_is_cancelled = false;
-    bool m_reversible = false;
-    bool m_has_error = false;
+    bool                        m_has_error = false;
+    bool                        m_reversible = false;
+    bool                        m_is_cancelled = false;
+    GCancellableWrapperPtr      m_cancellable_wrapper = nullptr;
 };
 
 }


### PR DESCRIPTION
[LINK] 38545

针对 fat、ntfs 等不支持特殊符号的 文件系统，在文件操作时候做了特殊处理