### PR TITLE
[FIX]  Double-click the shortcut key folder for special characters on…

### DIFF
--- a/libpeony-qt/file-info-job.cpp
+++ b/libpeony-qt/file-info-job.cpp
@@ -111,17 +111,14 @@ GAsyncReadyCallback FileInfoJob::query_info_async_callback(GFile *file, GAsyncRe
 
     GError *err = nullptr;
 
-    GFileInfo *_info = g_file_query_info_finish(file,
-                       res,
-                       &err);
+    GFileInfo *_info = g_file_query_info_finish(file, res, &err);
 
     if (_info != nullptr) {
         thisJob->refreshInfoContents(_info);
         g_object_unref(_info);
         Q_EMIT thisJob->queryAsyncFinished(true);
         Q_EMIT thisJob->infoUpdated();
-    }
-    else {
+    } else {
         if (err) {
             qDebug()<<err->code<<err->message;
             g_error_free(err);

--- a/libpeony-qt/file-info.cpp
+++ b/libpeony-qt/file-info.cpp
@@ -96,26 +96,19 @@ std::shared_ptr<FileInfo> FileInfo::fromUri(QString uri)
         std::shared_ptr<FileInfo> newly_info = std::make_shared<FileInfo>();
 
         newly_info->m_uri = uri;
-        newly_info->m_file = g_file_new_for_uri(uri.toUtf8().data());
+
+        // Special characters may cause a GFile creation to fail
+        GFile*  filet = g_file_new_for_uri(uri.toUtf8().data());
+        if (!g_file_query_exists(filet, nullptr)) {
+            if (filet) g_object_unref (filet);
+            char* name = g_uri_escape_string (uri.toUtf8().data(), G_URI_RESERVED_CHARS_ALLOWED_IN_PATH, TRUE);
+            filet = g_file_new_for_uri(name);
+            if (name) g_free (name);
+        }
+        newly_info->m_file = filet;
 
         newly_info->m_parent = g_file_get_parent(newly_info->m_file);
         newly_info->m_is_remote = !g_file_is_native(newly_info->m_file);
-        if (!newly_info->m_is_remote && false) {
-            GFileType type = g_file_query_file_type(newly_info->m_file, G_FILE_QUERY_INFO_NONE, nullptr);
-            switch (type) {
-            case G_FILE_TYPE_DIRECTORY:
-                //qDebug()<<"dir";
-                newly_info->m_is_dir = true;
-                break;
-            case G_FILE_TYPE_MOUNTABLE:
-                //qDebug()<<"mountable";
-                newly_info->m_is_volume = true;
-                break;
-            default:
-                break;
-            }
-        }
-
         newly_info = info_manager->insertFileInfo(newly_info);
         info_manager->unlock();
         return newly_info;
@@ -124,7 +117,7 @@ std::shared_ptr<FileInfo> FileInfo::fromUri(QString uri)
 
 std::shared_ptr<FileInfo> FileInfo::fromPath(QString path)
 {
-    QString uri = "file://"+path;
+    QString uri = "file://" + path;
     return fromUri(uri);
 }
 

--- a/libpeony-qt/model/file-item.cpp
+++ b/libpeony-qt/model/file-item.cpp
@@ -163,15 +163,7 @@ void FileItem::findChildrenAsync()
                 GFile *targetFile = g_file_new_for_uri(targetUri.toUtf8().constData());
                 QUrl targetUrl = targetUri;
                 auto path = g_file_get_path(targetFile);
-                if (path && !targetUrl.isLocalFile() && false) {
-                    QString localUri = QString("file://%1").arg(path);
-                    this->m_info = FileInfo::fromUri(localUri);
-                    enumerator->setEnumerateDirectory(localUri);
-                    g_free(path);
-                } else {
-                    enumerator->setEnumerateDirectory(targetFile);
-                }
-
+                enumerator->setEnumerateDirectory(targetFile);
                 g_object_unref(targetFile);
             }
 


### PR DESCRIPTION
… the desktop. It will prompt that the file cannot be found. Click OK and the file manager will flash back

[LINK] 39649

【文件管理器】双击桌面上特殊字符的快捷键文件夹，提示找不到文件，点击确定后文件管理器闪退
