### PR TITLE
Refactor desktop

### DIFF
--- a/libpeony-qt/controls/property-page/open-with-properties-page.cpp
+++ b/libpeony-qt/controls/property-page/open-with-properties-page.cpp
@@ -23,6 +23,7 @@
 #include "open-with-properties-page.h"
 #include "file-info.h"
 #include "file-launch-manager.h"
+#include "global-settings.h"
 
 #include <QLabel>
 #include <QPushButton>
@@ -183,7 +184,11 @@ void OpenWithPropertiesPage::initFloorThree()
     connect(otherOpenLabel, &QLabel::linkActivated, this, [=]() {
         QtConcurrent::run([=]() {
             QProcess p;
-            p.setProgram("ubuntu-kylin-software-center");
+            if (COMMERCIAL_VERSION)
+                p.setProgram("kylin-software-center");
+            else
+                p.setProgram("ubuntu-kylin-software-center");
+
 #if (QT_VERSION >= QT_VERSION_CHECK(5, 10, 0))
             p.startDetached();
 #else

--- a/libpeony-qt/controls/property-page/recent-and-trash-properties-page.cpp
+++ b/libpeony-qt/controls/property-page/recent-and-trash-properties-page.cpp
@@ -94,6 +94,8 @@ void RecentAndTrashPropertiesPage::init()
             m_layout->addWidget(checkbox);
             connect(checkbox, &QCheckBox::toggled, this, [=](bool checked){
                 this->setProperty("check", checked);
+                //fix bug 41657
+                GlobalSettings::getInstance()->setValue("showTrashDialog", checked);
             });
             auto value = GlobalSettings::getInstance()->getValue("showTrashDialog");
             if (value.isValid()) {

--- a/libpeony-qt/windows/format_dialog.cpp
+++ b/libpeony-qt/windows/format_dialog.cpp
@@ -25,6 +25,7 @@
 
 #include <QMessageBox>
 #include <QObject>
+#include <KWindowSystem>
 
 using namespace  Peony;
 static bool b_finished = false;
@@ -154,9 +155,12 @@ void Format_Dialog::acceptFormat(bool)
     ui->pushButton_close->setDisabled(true);
 
     //check format or not 
-   if(!format_makesure_dialog()){
+    if(!format_makesure_dialog()){
         return;
-   };
+    };
+
+    //keep this window above, fix bug #41227
+    KWindowSystem::setState(this->winId(), KWindowSystem::KeepAbove);
 
     //init the value
     char rom_size[1024] ={0},rom_type[1024]={0},rom_name[1024]={0},dev_name[1024]={0};

--- a/libpeony-qt/windows/format_dialog.ui
+++ b/libpeony-qt/windows/format_dialog.ui
@@ -42,7 +42,7 @@
   <widget class="QComboBox" name="comboBox_system">
    <property name="geometry">
     <rect>
-     <x>120</x>
+     <x>140</x>
      <y>80</y>
      <width>291</width>
      <height>26</height>
@@ -69,7 +69,7 @@
     <rect>
      <x>30</x>
      <y>140</y>
-     <width>151</width>
+     <width>101</width>
      <height>18</height>
     </rect>
    </property>
@@ -80,13 +80,13 @@
   <widget class="QLineEdit" name="lineEdit_device_name">
    <property name="geometry">
     <rect>
-     <x>120</x>
+     <x>140</x>
      <y>140</y>
      <width>291</width>
      <height>26</height>
     </rect>
-</property>
-    <property name="maxLength">
+   </property>
+   <property name="maxLength">
     <number>11</number>
    </property>
   </widget>
@@ -132,7 +132,7 @@
   <widget class="QComboBox" name="comboBox_rom_size">
    <property name="geometry">
     <rect>
-     <x>120</x>
+     <x>140</x>
      <y>20</y>
      <width>291</width>
      <height>26</height>

--- a/peony-qt-desktop/desktop-icon-view.cpp
+++ b/peony-qt-desktop/desktop-icon-view.cpp
@@ -682,8 +682,8 @@ void DesktopIconView::resolutionChange()
                 }
             }
 //            // first item doesn't need re-layout
-//            if (!needChanged.isEmpty())
-//                needChanged.removeFirst();
+            if (!needChanged.isEmpty())
+                needChanged.removeFirst();
 
             int posX = 0;
             int posY = 0;

--- a/peony-qt-desktop/desktop-icon-view.cpp
+++ b/peony-qt-desktop/desktop-icon-view.cpp
@@ -92,6 +92,7 @@ DesktopIconView::DesktopIconView(QWidget *parent) : QListView(parent)
 {
     //m_refresh_timer.setInterval(500);
     //m_refresh_timer.setSingleShot(true);
+    setAttribute(Qt::WA_AlwaysStackOnTop);
 
     installEventFilter(this);
 
@@ -107,7 +108,6 @@ DesktopIconView::DesktopIconView(QWidget *parent) : QListView(parent)
     m_edit_trigger_timer.setInterval(3000);
     m_last_index = QModelIndex();
 
-    setContentsMargins(0, 0, 0, 0);
     setAttribute(Qt::WA_TranslucentBackground);
 
     setHorizontalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
@@ -130,7 +130,6 @@ DesktopIconView::DesktopIconView(QWidget *parent) : QListView(parent)
 
     setDragDropMode(QListView::DragDrop);
 
-    //setContextMenuPolicy(Qt::CustomContextMenu);
     setSelectionMode(QListView::ExtendedSelection);
 
     auto zoomLevel = this->zoomLevel();
@@ -198,13 +197,50 @@ DesktopIconView::DesktopIconView(QWidget *parent) : QListView(parent)
         //panel monitor
         QGSettings *panelSetting = new QGSettings(PANEL_SETTINGS, QByteArray(), this);
         connect(panelSetting, &QGSettings::changed, this, [=](const QString &key){
-            qDebug() << "panelSetting changed:" << key;
-            if (key == "panelposition")
+            if (key == "panelposition" || key == "panelsize")
             {
-               auto zoomLevel = this->zoomLevel();
-               this->setDefaultZoomLevel(zoomLevel);
+                int position = panelSetting->get("panelposition").toInt();
+                int margins = panelSetting->get("panelsize").toInt();
+                switch (position) {
+                case 1: {
+                    setViewportMargins(0, margins, 0, 0);
+                    break;
+                }
+                case 2: {
+                    setViewportMargins(margins, 0, 0, 0);
+                    break;
+                }
+                case 3: {
+                    setViewportMargins(0, 0, margins, 0);
+                    break;
+                }
+                default: {
+                    setViewportMargins(0, 0, 0, margins);
+                    break;
+                }
+                }
             }
         });
+        int position = panelSetting->get("panelposition").toInt();
+        int margins = panelSetting->get("panelsize").toInt();
+        switch (position) {
+        case 1: {
+            setViewportMargins(0, margins, 0, 0);
+            break;
+        }
+        case 2: {
+            setViewportMargins(margins, 0, 0, 0);
+            break;
+        }
+        case 3: {
+            setViewportMargins(0, 0, margins, 0);
+            break;
+        }
+        default: {
+            setViewportMargins(0, 0, 0, margins);
+            break;
+        }
+        }
     }
 
     for (auto i = screens.constBegin(); i != screens.constEnd(); ++i) {
@@ -509,12 +545,6 @@ void DesktopIconView::initShoutCut()
 
 void DesktopIconView::initMenu()
 {
-    /*!
-     * \bug
-     *
-     * when view switch to another desktop window,
-     * menu might no be callable.
-     */
     return;
     setContextMenuPolicy(Qt::CustomContextMenu);
 

--- a/peony-qt-desktop/desktop-menu.cpp
+++ b/peony-qt-desktop/desktop-menu.cpp
@@ -282,9 +282,9 @@ const QList<QAction *> DesktopMenu::constructCreateTemplateActions()
                             if(!tmpIcon.isNull())
                                 isOnlyUnref = true;
                         }
-                        g_object_unref(app_infos);
                         l = l->next;
                     }
+                    g_list_free_full(app_infos, g_object_unref);
 
                     QAction *action = new QAction(tmpIcon, qinfo.baseName(), this);
                     connect(action, &QAction::triggered, [=]() {

--- a/peony-qt-desktop/desktop-window.h
+++ b/peony-qt-desktop/desktop-window.h
@@ -39,7 +39,7 @@ namespace Peony {
 
 class DesktopIconView;
 
-class DesktopWindow : public QMainWindow
+class DesktopWindow : public QWidget
 {
     Q_OBJECT
 

--- a/peony-qt-desktop/main.cpp
+++ b/peony-qt-desktop/main.cpp
@@ -79,6 +79,7 @@ void messageOutput(QtMsgType type, const QMessageLogContext &context, const QStr
 
 int main(int argc, char *argv[])
 {
+    //qputenv("QT_QPA_PLATFORM", "wayland");
     PeonyDesktopApplication::peony_desktop_start_time = QDateTime::currentMSecsSinceEpoch();
     qInstallMessageHandler(messageOutput);
     qDebug() << "desktop start time in main:" <<PeonyDesktopApplication::peony_desktop_start_time;

--- a/peony-qt-desktop/peony-desktop-application.cpp
+++ b/peony-qt-desktop/peony-desktop-application.cpp
@@ -121,6 +121,15 @@ QRect caculateVirtualDesktopGeometry() {
     for (auto screen : qApp->screens()) {
         screensRegion += screen->geometry();
     }
+
+    if (screensMonitor) {
+        int x = screensMonitor->getScreenGeometry("x");
+        int y = screensMonitor->getScreenGeometry("y");
+        int width = screensMonitor->getScreenGeometry("width");
+        int height = screensMonitor->getScreenGeometry("height");
+        screensRegion += QRect(x, y, width, height);
+    }
+
     auto rect = screensRegion.boundingRect();
     return rect;
 }
@@ -317,7 +326,7 @@ void PeonyDesktopApplication::parseCmd(quint32 id, QByteArray msg, bool isPrimar
                 virtualDesktopWindow->setAttribute(Qt::WA_X11NetWmWindowTypeDesktop);
                 //virtualDesktopWindow->setAttribute(Qt::WA_TranslucentBackground);
                 auto virtualDesktopWindowRect = caculateVirtualDesktopGeometry();
-                virtualDesktopWindow->resize(virtualDesktopWindowRect.size());
+                virtualDesktopWindow->setFixedSize(virtualDesktopWindowRect.size());
                 virtualDesktopWindow->show();
 
                 virtualDesktopWindow->setContextMenuPolicy(Qt::CustomContextMenu);
@@ -388,6 +397,8 @@ void PeonyDesktopApplication::parseCmd(quint32 id, QByteArray msg, bool isPrimar
         if (QString(qgetenv("DESKTOP_SESSION")) == "ukui-wayland") {
             screensMonitor = new PrimaryManager;
             connect(screensMonitor, &PrimaryManager::priScreenChangedSignal, this, [=](int x, int y, int width, int height){
+                auto virtualDesktopWindowRect = caculateVirtualDesktopGeometry();
+                virtualDesktopWindow->setFixedSize(virtualDesktopWindowRect.size());
                 getIconView()->setGeometry(x, y, width, height);
             });
             screensMonitor->start();
@@ -418,12 +429,12 @@ void PeonyDesktopApplication::parseCmd(quint32 id, QByteArray msg, bool isPrimar
 void PeonyDesktopApplication::addWindow(QScreen *screen, bool checkPrimay)
 {
     auto virtualDesktopWindowRect = caculateVirtualDesktopGeometry();
-    virtualDesktopWindow->resize(virtualDesktopWindowRect.size());
+    virtualDesktopWindow->setFixedSize(virtualDesktopWindowRect.size());
     if (screen != nullptr) {
         qDebug()<<"screenAdded"<<screen->name()<<screen<<m_window_list.size()<<screen->availableSize();
         connect(screen, &QScreen::geometryChanged, this, [=](){
             auto virtualDesktopWindowRect = caculateVirtualDesktopGeometry();
-            virtualDesktopWindow->resize(virtualDesktopWindowRect.size());
+            virtualDesktopWindow->setFixedSize(virtualDesktopWindowRect.size());
         });
     } else {
         return;
@@ -479,7 +490,7 @@ void PeonyDesktopApplication::screenAddedProcess(QScreen *screen)
 void PeonyDesktopApplication::screenRemovedProcess(QScreen *screen)
 {
     auto virtualDesktopWindowRect = caculateVirtualDesktopGeometry();
-    virtualDesktopWindow->resize(virtualDesktopWindowRect.size());
+    virtualDesktopWindow->setFixedSize(virtualDesktopWindowRect.size());
     //if (screen != nullptr)
     //qDebug()<<"screenRemoved"<<screen->name()<<screen->serialNumber();
 

--- a/peony-qt-desktop/peony-desktop-application.cpp
+++ b/peony-qt-desktop/peony-desktop-application.cpp
@@ -417,6 +417,18 @@ void PeonyDesktopApplication::parseCmd(quint32 id, QByteArray msg, bool isPrimar
 
 void PeonyDesktopApplication::addWindow(QScreen *screen, bool checkPrimay)
 {
+    auto virtualDesktopWindowRect = caculateVirtualDesktopGeometry();
+    virtualDesktopWindow->resize(virtualDesktopWindowRect.size());
+    if (screen != nullptr) {
+        qDebug()<<"screenAdded"<<screen->name()<<screen<<m_window_list.size()<<screen->availableSize();
+        connect(screen, &QScreen::geometryChanged, this, [=](){
+            auto virtualDesktopWindowRect = caculateVirtualDesktopGeometry();
+            virtualDesktopWindow->resize(virtualDesktopWindowRect.size());
+        });
+    } else {
+        return;
+    }
+
     Peony::DesktopWindow *window;
     if (checkPrimay) {
         bool is_primary = isPrimaryScreen(screen);
@@ -461,18 +473,6 @@ void PeonyDesktopApplication::primaryScreenChangedProcess(QScreen *screen)
 
 void PeonyDesktopApplication::screenAddedProcess(QScreen *screen)
 {
-    auto virtualDesktopWindowRect = caculateVirtualDesktopGeometry();
-    virtualDesktopWindow->resize(virtualDesktopWindowRect.size());
-    if (screen != nullptr) {
-        qDebug()<<"screenAdded"<<screen->name()<<screen<<m_window_list.size()<<screen->availableSize();
-        connect(screen, &QScreen::geometryChanged, this, [=](){
-            auto virtualDesktopWindowRect = caculateVirtualDesktopGeometry();
-            virtualDesktopWindow->resize(virtualDesktopWindowRect.size());
-        });
-    } else {
-        return;
-    }
-
     addWindow(screen, false);
 }
 

--- a/peony-qt-desktop/peony-desktop-application.cpp
+++ b/peony-qt-desktop/peony-desktop-application.cpp
@@ -461,9 +461,15 @@ void PeonyDesktopApplication::primaryScreenChangedProcess(QScreen *screen)
 
 void PeonyDesktopApplication::screenAddedProcess(QScreen *screen)
 {
-    if (screen != nullptr)
+    auto virtualDesktopWindowRect = caculateVirtualDesktopGeometry();
+    virtualDesktopWindow->resize(virtualDesktopWindowRect.size());
+    if (screen != nullptr) {
         qDebug()<<"screenAdded"<<screen->name()<<screen<<m_window_list.size()<<screen->availableSize();
-    else {
+        connect(screen, &QScreen::geometryChanged, this, [=](){
+            auto virtualDesktopWindowRect = caculateVirtualDesktopGeometry();
+            virtualDesktopWindow->resize(virtualDesktopWindowRect.size());
+        });
+    } else {
         return;
     }
 
@@ -472,6 +478,8 @@ void PeonyDesktopApplication::screenAddedProcess(QScreen *screen)
 
 void PeonyDesktopApplication::screenRemovedProcess(QScreen *screen)
 {
+    auto virtualDesktopWindowRect = caculateVirtualDesktopGeometry();
+    virtualDesktopWindow->resize(virtualDesktopWindowRect.size());
     //if (screen != nullptr)
     //qDebug()<<"screenRemoved"<<screen->name()<<screen->serialNumber();
 

--- a/peony-qt-desktop/peony-desktop-application.cpp
+++ b/peony-qt-desktop/peony-desktop-application.cpp
@@ -31,6 +31,8 @@
 #include "desktop-icon-view.h"
 
 #include "primary-manager.h"
+#include "plasma-shell-manager.h"
+#include "desktop-menu.h"
 
 #include <QCommandLineParser>
 #include <QCommandLineOption>
@@ -55,6 +57,8 @@
 #include <QDBusReply>
 #include <QDesktopServices>
 
+#include <QScreen>
+
 #define KYLIN_USER_GUIDE_PATH "/"
 #define KYLIN_USER_GUIDE_SERVICE QString("com.kylinUserGuide.hotel_%1").arg(getuid())
 #define KYLIN_USER_GUIDE_INTERFACE "com.guide.hotel"
@@ -65,6 +69,7 @@ static bool has_desktop = false;
 static bool has_daemon = false;
 static Peony::DesktopIconView *desktop_icon_view = nullptr;
 static PrimaryManager *screensMonitor = nullptr;
+static QMainWindow *virtualDesktopWindow = nullptr;
 
 //record of desktop start time
 qint64 PeonyDesktopApplication::peony_desktop_start_time = 0;
@@ -109,6 +114,15 @@ void trySetDefaultFolderUrlHandler() {
             return;
         });
     });
+}
+
+QRect caculateVirtualDesktopGeometry() {
+    QRegion screensRegion;
+    for (auto screen : qApp->screens()) {
+        screensRegion += screen->geometry();
+    }
+    auto rect = screensRegion.boundingRect();
+    return rect;
 }
 
 PeonyDesktopApplication::PeonyDesktopApplication(int &argc, char *argv[], const char *applicationName) : SingleApplication (argc, argv, applicationName, true)
@@ -175,33 +189,12 @@ PeonyDesktopApplication::PeonyDesktopApplication(int &argc, char *argv[], const 
         g_mount_guess_content_type(newMount,FALSE,NULL,guessContentTypeCallback,NULL);
     });
     connect(volumeManager,&Peony::VolumeManager::volumeRemoved,this,&PeonyDesktopApplication::volumeRemovedProcess);
-
-    // check ukui wayland session, monitor ukui settings daemon dbus
-    if (QString(qgetenv("DESKTOP_SESSION")) == "ukui-wayland") {
-        screensMonitor = new PrimaryManager;
-        connect(screensMonitor, &PrimaryManager::priScreenChangedSignal, this, [=](int x, int y, int width, int height){
-            for (auto screen : this->screens()) {
-                if (screen->geometry() == QRect(x, y, width, height))
-                    Q_EMIT this->primaryScreenChanged(screen);
-            }
-        });
-        screensMonitor->start();
-        // init
-        int x = screensMonitor->getScreenGeometry("x");
-        int y = screensMonitor->getScreenGeometry("y");
-        int width = screensMonitor->getScreenGeometry("width");
-        int height = screensMonitor->getScreenGeometry("height");
-        for (auto screen : this->screens()) {
-            if (screen->geometry() == QRect(x, y, width, height))
-                Q_EMIT this->primaryScreenChanged(screen);
-        }
-    }
 }
 
 Peony::DesktopIconView *PeonyDesktopApplication::getIconView()
 {
     if (!desktop_icon_view)
-        desktop_icon_view = new Peony::DesktopIconView;
+        desktop_icon_view = new Peony::DesktopIconView(virtualDesktopWindow);
     return desktop_icon_view;
 }
 
@@ -319,15 +312,69 @@ void PeonyDesktopApplication::parseCmd(quint32 id, QByteArray msg, bool isPrimar
 
         if (parser.isSet(desktopOption)) {
             if (!has_desktop) {
-                //FIXME: load menu plugin
-                //FIXME: take over desktop displaying
-                getIconView();
+                virtualDesktopWindow = new QMainWindow;
+                virtualDesktopWindow->setWindowFlag(Qt::FramelessWindowHint);
+                virtualDesktopWindow->setAttribute(Qt::WA_X11NetWmWindowTypeDesktop);
+                //virtualDesktopWindow->setAttribute(Qt::WA_TranslucentBackground);
+                auto virtualDesktopWindowRect = caculateVirtualDesktopGeometry();
+                virtualDesktopWindow->resize(virtualDesktopWindowRect.size());
+                virtualDesktopWindow->show();
+
+                virtualDesktopWindow->setContextMenuPolicy(Qt::CustomContextMenu);
+                virtualDesktopWindow->connect(virtualDesktopWindow, &QMainWindow::customContextMenuRequested, virtualDesktopWindow, [=](const QPoint &pos){
+                    qWarning()<<pos;
+                    auto fixedPos = getIconView()->mapFromGlobal(pos);
+                    auto index = PeonyDesktopApplication::getIconView()->indexAt(fixedPos);
+                    if (!index.isValid()) {
+                        PeonyDesktopApplication::getIconView()->clearSelection();
+                    } else {
+                        if (!PeonyDesktopApplication::getIconView()->selectionModel()->selection().indexes().contains(index)) {
+                            PeonyDesktopApplication::getIconView()->clearSelection();
+                            PeonyDesktopApplication::getIconView()->selectionModel()->select(index, QItemSelectionModel::Select);
+                        }
+                    }
+
+                    QTimer::singleShot(1, [=]() {
+                        DesktopMenu menu(PeonyDesktopApplication::getIconView());
+                        if (PeonyDesktopApplication::getIconView()->getSelections().isEmpty()) {
+                            auto action = menu.addAction(tr("set background"));
+                            connect(action, &QAction::triggered, [=]() {
+                                //go to control center set background
+                                DesktopWindow::gotoSetBackground();
+            //                    QFileDialog dlg;
+            //                    dlg.setNameFilters(QStringList() << "*.jpg"
+            //                                       << "*.png");
+            //                    if (dlg.exec()) {
+            //                        auto url = dlg.selectedUrls().first();
+            //                        this->setBg(url.path());
+            //                        // qDebug()<<url;
+            //                        Q_EMIT this->changeBg(url.path());
+            //                    }
+                            });
+                        }
+
+                        for (auto screen : qApp->screens()) {
+                            if (screen->geometry().contains(pos));
+                            //menu.windowHandle()->setScreen(screen);
+                        }
+                        menu.exec(pos);
+                        auto urisToEdit = menu.urisToEdit();
+                        if (urisToEdit.count() == 1) {
+                            QTimer::singleShot(
+                            100, this, [=]() {
+                                PeonyDesktopApplication::getIconView()->editUri(urisToEdit.first());
+                            });
+                        }
+                    });
+                });
+
                 for(auto screen : this->screens())
                 {
                     addWindow(screen);
                 }
             }
             has_desktop = true;
+            PlasmaShellManager::getInstance()->setRole(virtualDesktopWindow->windowHandle(), KWayland::Client::PlasmaShellSurface::Role::Desktop);
         }
 
         connect(this, &QApplication::paletteChanged, this, [=](const QPalette &pal) {
@@ -336,6 +383,24 @@ void PeonyDesktopApplication::parseCmd(quint32 id, QByteArray msg, bool isPrimar
                 w->update();
             }
         });
+
+        // check ukui wayland session, monitor ukui settings daemon dbus
+        if (QString(qgetenv("DESKTOP_SESSION")) == "ukui-wayland") {
+            screensMonitor = new PrimaryManager;
+            connect(screensMonitor, &PrimaryManager::priScreenChangedSignal, this, [=](int x, int y, int width, int height){
+                getIconView()->setGeometry(x, y, width, height);
+            });
+            screensMonitor->start();
+            // init
+            getIconView()->show();
+            int x = screensMonitor->getScreenGeometry("x");
+            int y = screensMonitor->getScreenGeometry("y");
+            int width = screensMonitor->getScreenGeometry("width");
+            int height = screensMonitor->getScreenGeometry("height");
+            getIconView()->setGeometry(x, y, width, height);
+        } else {
+            getIconView()->setGeometry(qApp->primaryScreen()->availableGeometry());
+        }
     }
     else {
         auto helpOption = parser.addHelpOption();
@@ -355,15 +420,15 @@ void PeonyDesktopApplication::addWindow(QScreen *screen, bool checkPrimay)
     Peony::DesktopWindow *window;
     if (checkPrimay) {
         bool is_primary = isPrimaryScreen(screen);
-        window = new Peony::DesktopWindow(screen, is_primary);
+        window = new Peony::DesktopWindow(screen, is_primary, virtualDesktopWindow);
         if (is_primary)
         {
-            window->setCentralWidget(desktop_icon_view);
+//            window->setCentralWidget(desktop_icon_view);
             window->updateView();
             //connect(window, &Peony::DesktopWindow::changeBg, this, &PeonyDesktopApplication::changeBgProcess);
         }
     } else {
-        window = new Peony::DesktopWindow(screen, false);
+        window = new Peony::DesktopWindow(screen, false, virtualDesktopWindow);
     }
 
     connect(window, &Peony::DesktopWindow::checkWindow, this, &PeonyDesktopApplication::checkWindowProcess);
@@ -373,6 +438,11 @@ void PeonyDesktopApplication::addWindow(QScreen *screen, bool checkPrimay)
     for (auto window : m_window_list) {
         window->updateWinGeometry();
     }
+
+    window->show();
+
+    getIconView()->show();
+    getIconView()->raise();
 }
 
 void PeonyDesktopApplication::layoutDirectionChangedProcess(Qt::LayoutDirection direction)
@@ -383,79 +453,10 @@ void PeonyDesktopApplication::layoutDirectionChangedProcess(Qt::LayoutDirection 
 
 void PeonyDesktopApplication::primaryScreenChangedProcess(QScreen *screen)
 {
-    if (screen != nullptr)
-        qDebug()<<"primaryScreenChangedProcess"<<screen->name()<<screen->geometry()<<screen->availableGeometry()<<screen->virtualGeometry();
-    else {
-        qWarning()<<"no primary screen!";
+    if (screensMonitor)
         return;
-    }
-
-    bool need_exchange = false;
-    QScreen *preMainScreen = nullptr;
-    Peony::DesktopWindow *rawPrimaryWindow = nullptr;
-    Peony::DesktopWindow *currentPrimayWindow = nullptr;
-    for(auto win : m_window_list)
-    {
-        if (win->centralWidget())
-            rawPrimaryWindow = win;
-
-        if (win->getScreen() == screen)
-            currentPrimayWindow = win;
-        //need exchange window screen
-//        if (win->getView() && win->getScreen() != screen)
-//        {
-//            preMainScreen = win->getScreen();
-//            need_exchange = true;
-//            break;
-//        }
-    }
-
-    if (rawPrimaryWindow && currentPrimayWindow) {
-        currentPrimayWindow->setCentralWidget(getIconView());
-        //desktop_icon_view->show();
-        currentPrimayWindow->updateView();
-        currentPrimayWindow->hide();
-        currentPrimayWindow->show();
-    } else {
-        currentPrimayWindow = qobject_cast<DesktopWindow *>(getIconView()->topLevelWidget());
-        currentPrimayWindow->setCentralWidget(getIconView());
-        //desktop_icon_view->show();
-        currentPrimayWindow->updateView();
-        currentPrimayWindow->hide();
-        currentPrimayWindow->show();
-    }
-    if (currentPrimayWindow) {
-        currentPrimayWindow->activateWindow();
-        currentPrimayWindow->raise();
-    }
-
-    return;
-
-    //do not check window need exchange
-    //cause we always put the desktop icon view into window
-    //which in current primary screen.
-    if (need_exchange)
-    {
-        for(auto win : m_window_list)
-        {
-            //qDebug()<<"before screen info"<<win->getScreen()->name()<<win->getScreen()->geometry()<<win->geometry()<<preMainScreen->name();
-            win->disconnectSignal();
-            if (win->getScreen() == preMainScreen)
-            {
-                win->setScreen(screen);
-                win->setIsPrimary(true);
-            }
-            else if (win->getScreen() == screen) {
-                win->setScreen(preMainScreen);
-                win->setIsPrimary(false);
-            }
-            win->connectSignal();
-            win->updateWinGeometry();
-            //qDebug()<<"end screen info"<<win->getScreen()->name()<<win->getScreen()->geometry()<<win->geometry();
-            //if (win->getView())
-            //qDebug()<<"view info:"<<win->getView();
-        }
-    }
+    getIconView()->setGeometry(screen->availableGeometry());
+    getIconView()->raise();
 }
 
 void PeonyDesktopApplication::screenAddedProcess(QScreen *screen)
@@ -482,32 +483,8 @@ void PeonyDesktopApplication::screenRemovedProcess(QScreen *screen)
         {
             qDebug()<<"remove window";
             m_window_list.removeOne(win);
-            win->setCentralWidget(nullptr);
+//            win->setCentralWidget(nullptr);
             win->deleteLater();
-        }
-
-        // check if there is primary screen
-        bool hasPrimaryScreen = false;
-        if (!getIconView()->parentWidget()) {
-            // init
-            int x = screensMonitor->getScreenGeometry("x");
-            int y = screensMonitor->getScreenGeometry("y");
-            int width = screensMonitor->getScreenGeometry("width");
-            int height = screensMonitor->getScreenGeometry("height");
-            screensMonitor->deleteLater();
-            for (auto screen : this->screens()) {
-                if (screen->geometry() == QRect(x, y, width, height)) {
-                    hasPrimaryScreen = true;
-                    Q_EMIT this->primaryScreenChanged(screen);
-                }
-            }
-        }
-
-        // check again
-        if (!hasPrimaryScreen) {
-            if (!m_window_list.isEmpty()) {
-                Q_EMIT this->primaryScreenChanged(m_window_list.first()->getScreen());
-            }
         }
     }
 }

--- a/peony-qt-desktop/peony-qt-desktop.pro
+++ b/peony-qt-desktop/peony-qt-desktop.pro
@@ -4,7 +4,7 @@
 #
 #-------------------------------------------------
 
-QT       += core gui x11extras dbus concurrent KWindowSystem
+QT       += core gui x11extras dbus concurrent KWindowSystem KWaylandClient
 
 greaterThan(QT_MAJOR_VERSION, 4): QT += widgets
 
@@ -47,6 +47,7 @@ SOURCES += \
     peony-json-operation.cpp \
     bw-list-info.cpp \
     peony-dbus-service.cpp \
+    plasma-shell-manager.cpp \
     primary-manager.cpp \
     user-dir-manager.cpp
 
@@ -64,6 +65,7 @@ HEADERS += \
     peony-json-operation.h \
     bw-list-info.h \
     peony-dbus-service.h \
+    plasma-shell-manager.h \
     primary-manager.h \
     user-dir-manager.h
 

--- a/peony-qt-desktop/plasma-shell-manager.cpp
+++ b/peony-qt-desktop/plasma-shell-manager.cpp
@@ -1,0 +1,99 @@
+/*
+ * Peony-Qt
+ *
+ * Copyright (C) 2020, KylinSoft Co., Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Authors: Yue Lan <lanyue@kylinos.cn>
+ *
+ */
+
+#include "plasma-shell-manager.h"
+
+#include <QApplication>
+
+#include <KWayland/Client/connection_thread.h>
+#include <KWayland/Client/registry.h>
+
+#include <KWayland/Client/surface.h>
+
+#include <QX11Info>
+
+static PlasmaShellManager* global_instance = nullptr;
+
+PlasmaShellManager *PlasmaShellManager::getInstance()
+{
+    if (!global_instance)
+        global_instance = new PlasmaShellManager;
+    return global_instance;
+}
+
+bool PlasmaShellManager::setRole(QWindow *window, KWayland::Client::PlasmaShellSurface::Role role)
+{
+    if (!supportPlasmaShell())
+        return false;
+
+    auto surface = KWayland::Client::Surface::fromWindow(window);
+    if (!surface)
+        return false;
+
+    auto plasmaShellSurface = m_shell->createSurface(surface, window);
+    if (!plasmaShellSurface)
+        return false;
+
+    plasmaShellSurface->setRole(role);
+    return true;
+}
+
+bool PlasmaShellManager::setPos(QWindow *window, const QPoint &pos)
+{
+    if (!supportPlasmaShell())
+        return false;
+
+    auto surface = KWayland::Client::Surface::fromWindow(window);
+    if (!surface)
+        return false;
+
+    auto plasmaShellSurface = m_shell->createSurface(surface, window);
+    if (!plasmaShellSurface)
+        return false;
+
+    plasmaShellSurface->setPosition(pos);
+    return true;
+}
+
+bool PlasmaShellManager::supportPlasmaShell()
+{
+    return m_shell;
+}
+
+PlasmaShellManager::PlasmaShellManager(QObject *parent) : QObject(parent)
+{
+    if (QX11Info::isPlatformX11() || QString(qgetenv("QT_QPA_PLATFORM")) != "wayland" || !QString(qgetenv("XDG_SESSION_DESKTOP")).contains("ukui-wayland"))
+        return;
+    auto connection = KWayland::Client::ConnectionThread::fromApplication(qApp);
+    auto registry = new KWayland::Client::Registry(this);
+    registry->create(connection->display());
+
+    connect(registry, &KWayland::Client::Registry::plasmaShellAnnounced, this, [=](){
+        const auto interface = registry->interface(KWayland::Client::Registry::Interface::PlasmaShell);
+        if (interface.name != 0) {
+            m_shell = registry->createPlasmaShell(interface.name, interface.version, this);
+        }
+    });
+
+    registry->setup();
+    connection->roundtrip();
+}

--- a/peony-qt-desktop/plasma-shell-manager.h
+++ b/peony-qt-desktop/plasma-shell-manager.h
@@ -1,0 +1,46 @@
+/*
+ * Peony-Qt
+ *
+ * Copyright (C) 2020, KylinSoft Co., Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Authors: Yue Lan <lanyue@kylinos.cn>
+ *
+ */
+
+#ifndef PLASMASHELLMANAGER_H
+#define PLASMASHELLMANAGER_H
+
+#include <QObject>
+#include <QWindow>
+#include <KWayland/Client/plasmashell.h>
+
+class PlasmaShellManager : public QObject
+{
+    Q_OBJECT
+public:
+    static PlasmaShellManager *getInstance();
+
+    bool setRole(QWindow *window, KWayland::Client::PlasmaShellSurface::Role role);
+    bool setPos(QWindow *window, const QPoint &pos);
+    bool supportPlasmaShell();
+
+private:
+    explicit PlasmaShellManager(QObject *parent = nullptr);
+
+    KWayland::Client::PlasmaShell *m_shell = nullptr;
+};
+
+#endif // PLASMASHELLMANAGER_H

--- a/peony-qt-desktop/primary-manager.cpp
+++ b/peony-qt-desktop/primary-manager.cpp
@@ -1,3 +1,25 @@
+/*
+ * Peony-Qt
+ *
+ * Copyright (C) 2020, KylinSoft Co., Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Authors: Yue Lan <lanyue@kylinos.cn>
+ *
+ */
+
 #include "primary-manager.h"
 #include <QDebug>
 #include <QTimer>
@@ -79,9 +101,5 @@ QString PrimaryManager::getScreenName(QString methodName)
 void PrimaryManager::priScreenChanged(int x, int y, int width, int height)
 {
     Q_EMIT this->priScreenChangedSignal(x, y, width, height);
-    // re-check
-    QTimer::singleShot(500, this, [=](){
-        Q_EMIT this->priScreenChangedSignal(x, y, width, height);
-    });
     qDebug("primary screen  changed, geometry is  x=%d, y=%d, windth=%d, height=%d", x, y, width, height);
 }

--- a/peony-qt-desktop/primary-manager.h
+++ b/peony-qt-desktop/primary-manager.h
@@ -1,3 +1,25 @@
+/*
+ * Peony-Qt
+ *
+ * Copyright (C) 2020, KylinSoft Co., Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Authors: Yue Lan <lanyue@kylinos.cn>
+ *
+ */
+
 #ifndef PRIMARYMANAGER_H
 #define PRIMARYMANAGER_H
 

--- a/src/control/tab-widget.cpp
+++ b/src/control/tab-widget.cpp
@@ -892,15 +892,19 @@ void TabWidget::addPage(const QString &uri, bool jumpTo)
 {
     auto viewContainer = new Peony::DirectoryViewContainer(m_stack);
     bool hasCurrentPage = currentPage();
+    bool hasView = false;
+    if (hasCurrentPage)
+        hasView = currentPage()->getView();
     int zoomLevel = -1;
 
     if (hasCurrentPage) {
         // perfer to use current page view type
         auto internalViews = Peony::DirectoryViewFactoryManager2::getInstance()->internalViews();
-        if (internalViews.contains(currentPage()->getView()->viewId()))
+        //fix continuously click add button quickly crash issue, bug #41425
+        if (hasView && internalViews.contains(currentPage()->getView()->viewId()))
             viewContainer->switchViewType(currentPage()->getView()->viewId());
 
-        if (currentPage()) {
+        if (hasView && hasCurrentPage) {
             hasCurrentPage = true;
             zoomLevel = currentPage()->getView()->currentZoomLevel();
         }

--- a/translations/peony-qt-desktop/peony-qt-desktop_cs.ts
+++ b/translations/peony-qt-desktop/peony-qt-desktop_cs.ts
@@ -9,32 +9,32 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../peony-qt-desktop/desktop-icon-view.cpp" line="450"/>
+        <location filename="../../peony-qt-desktop/desktop-icon-view.cpp" line="486"/>
         <source>New Folder</source>
         <translation type="unfinished">Yeni Klasör</translation>
     </message>
     <message>
-        <location filename="../../peony-qt-desktop/desktop-icon-view.cpp" line="536"/>
+        <location filename="../../peony-qt-desktop/desktop-icon-view.cpp" line="566"/>
         <source>set background</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../peony-qt-desktop/desktop-icon-view.cpp" line="699"/>
+        <location filename="../../peony-qt-desktop/desktop-icon-view.cpp" line="729"/>
         <source>Open Link failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../peony-qt-desktop/desktop-icon-view.cpp" line="700"/>
+        <location filename="../../peony-qt-desktop/desktop-icon-view.cpp" line="730"/>
         <source>File not exist, do you want to delete the link file?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../peony-qt-desktop/desktop-icon-view.cpp" line="715"/>
+        <location filename="../../peony-qt-desktop/desktop-icon-view.cpp" line="745"/>
         <source>Open failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../peony-qt-desktop/desktop-icon-view.cpp" line="716"/>
+        <location filename="../../peony-qt-desktop/desktop-icon-view.cpp" line="746"/>
         <source>Open directory failed, you have no permission!</source>
         <translation type="unfinished"></translation>
     </message>
@@ -258,11 +258,6 @@
         <translation type="unfinished">Masaüstü</translation>
     </message>
     <message>
-        <location filename="../../peony-qt-desktop/desktop-window.cpp" line="161"/>
-        <source>set background</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>New Folder</source>
         <translation type="vanished">Yeni Klasör</translation>
     </message>
@@ -274,7 +269,7 @@
         <translation type="vanished">Masaüstünü kapatın ve çıkın</translation>
     </message>
     <message>
-        <location filename="../../peony-qt-desktop/peony-desktop-application.cpp" line="128"/>
+        <location filename="../../peony-qt-desktop/peony-desktop-application.cpp" line="142"/>
         <source>peony-qt-desktop</source>
         <translation>Masaüstü</translation>
     </message>
@@ -287,18 +282,23 @@
         <translation type="vanished">Masaüstü</translation>
     </message>
     <message>
-        <location filename="../../peony-qt-desktop/peony-desktop-application.cpp" line="251"/>
+        <location filename="../../peony-qt-desktop/peony-desktop-application.cpp" line="244"/>
         <source>Close the peony desktop window</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../peony-qt-desktop/peony-desktop-application.cpp" line="254"/>
+        <location filename="../../peony-qt-desktop/peony-desktop-application.cpp" line="247"/>
         <source>Take over the dbus service.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../peony-qt-desktop/peony-desktop-application.cpp" line="257"/>
+        <location filename="../../peony-qt-desktop/peony-desktop-application.cpp" line="250"/>
         <source>Take over the desktop displaying</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../peony-qt-desktop/peony-desktop-application.cpp" line="340"/>
+        <source>set background</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/peony-qt-desktop/peony-qt-desktop_tr.ts
+++ b/translations/peony-qt-desktop/peony-qt-desktop_tr.ts
@@ -9,12 +9,12 @@
         <translation>Masaüstü Simgelerini Göster</translation>
     </message>
     <message>
-        <location filename="../../peony-qt-desktop/desktop-icon-view.cpp" line="450"/>
+        <location filename="../../peony-qt-desktop/desktop-icon-view.cpp" line="486"/>
         <source>New Folder</source>
         <translation>Yeni Klasör</translation>
     </message>
     <message>
-        <location filename="../../peony-qt-desktop/desktop-icon-view.cpp" line="536"/>
+        <location filename="../../peony-qt-desktop/desktop-icon-view.cpp" line="566"/>
         <source>set background</source>
         <translation>Arkaplanı Değiştir</translation>
     </message>
@@ -23,22 +23,22 @@
         <translation type="obsolete">Dosyayı Sil Uyarısı</translation>
     </message>
     <message>
-        <location filename="../../peony-qt-desktop/desktop-icon-view.cpp" line="699"/>
+        <location filename="../../peony-qt-desktop/desktop-icon-view.cpp" line="729"/>
         <source>Open Link failed</source>
         <translation type="unfinished">Bağlantı Açılamadı</translation>
     </message>
     <message>
-        <location filename="../../peony-qt-desktop/desktop-icon-view.cpp" line="700"/>
+        <location filename="../../peony-qt-desktop/desktop-icon-view.cpp" line="730"/>
         <source>File not exist, do you want to delete the link file?</source>
         <translation type="unfinished">Dosya mevcut değil, bağlantı dosyasını silmek istiyor musunuz?</translation>
     </message>
     <message>
-        <location filename="../../peony-qt-desktop/desktop-icon-view.cpp" line="715"/>
+        <location filename="../../peony-qt-desktop/desktop-icon-view.cpp" line="745"/>
         <source>Open failed</source>
         <translation type="unfinished">Açma hatalı</translation>
     </message>
     <message>
-        <location filename="../../peony-qt-desktop/desktop-icon-view.cpp" line="716"/>
+        <location filename="../../peony-qt-desktop/desktop-icon-view.cpp" line="746"/>
         <source>Open directory failed, you have no permission!</source>
         <translation type="unfinished">Dizin açılamadı, izniniz yok!</translation>
     </message>
@@ -342,9 +342,8 @@
         <translation>Masaüstü</translation>
     </message>
     <message>
-        <location filename="../../peony-qt-desktop/desktop-window.cpp" line="161"/>
         <source>set background</source>
-        <translation>Arkaplanı Değiştir</translation>
+        <translation type="vanished">Arkaplanı Değiştir</translation>
     </message>
     <message>
         <source>New Folder</source>
@@ -358,7 +357,7 @@
         <translation type="vanished">Masaüstünü kapatın ve çıkın</translation>
     </message>
     <message>
-        <location filename="../../peony-qt-desktop/peony-desktop-application.cpp" line="128"/>
+        <location filename="../../peony-qt-desktop/peony-desktop-application.cpp" line="142"/>
         <source>peony-qt-desktop</source>
         <translation>Masaüstü</translation>
     </message>
@@ -371,19 +370,24 @@
         <translation type="vanished">Masaüstü</translation>
     </message>
     <message>
-        <location filename="../../peony-qt-desktop/peony-desktop-application.cpp" line="251"/>
+        <location filename="../../peony-qt-desktop/peony-desktop-application.cpp" line="244"/>
         <source>Close the peony desktop window</source>
         <translation>Peony masaüstü penceresini kapat</translation>
     </message>
     <message>
-        <location filename="../../peony-qt-desktop/peony-desktop-application.cpp" line="254"/>
+        <location filename="../../peony-qt-desktop/peony-desktop-application.cpp" line="247"/>
         <source>Take over the dbus service.</source>
         <translation>Dbus servisini al</translation>
     </message>
     <message>
-        <location filename="../../peony-qt-desktop/peony-desktop-application.cpp" line="257"/>
+        <location filename="../../peony-qt-desktop/peony-desktop-application.cpp" line="250"/>
         <source>Take over the desktop displaying</source>
         <translation>Masaüstü görüntülemeyi al</translation>
+    </message>
+    <message>
+        <location filename="../../peony-qt-desktop/peony-desktop-application.cpp" line="340"/>
+        <source>set background</source>
+        <translation type="unfinished">Arkaplanı Değiştir</translation>
     </message>
 </context>
 </TS>

--- a/translations/peony-qt-desktop/peony-qt-desktop_zh_CN.ts
+++ b/translations/peony-qt-desktop/peony-qt-desktop_zh_CN.ts
@@ -9,12 +9,12 @@
         <translation>桌面图标视图</translation>
     </message>
     <message>
-        <location filename="../../peony-qt-desktop/desktop-icon-view.cpp" line="450"/>
+        <location filename="../../peony-qt-desktop/desktop-icon-view.cpp" line="486"/>
         <source>New Folder</source>
         <translation>新建文件夹</translation>
     </message>
     <message>
-        <location filename="../../peony-qt-desktop/desktop-icon-view.cpp" line="536"/>
+        <location filename="../../peony-qt-desktop/desktop-icon-view.cpp" line="566"/>
         <source>set background</source>
         <translation>设置壁纸</translation>
     </message>
@@ -23,22 +23,22 @@
         <translation type="vanished">删除文件警告</translation>
     </message>
     <message>
-        <location filename="../../peony-qt-desktop/desktop-icon-view.cpp" line="715"/>
+        <location filename="../../peony-qt-desktop/desktop-icon-view.cpp" line="745"/>
         <source>Open failed</source>
         <translation>打开失败</translation>
     </message>
     <message>
-        <location filename="../../peony-qt-desktop/desktop-icon-view.cpp" line="716"/>
+        <location filename="../../peony-qt-desktop/desktop-icon-view.cpp" line="746"/>
         <source>Open directory failed, you have no permission!</source>
         <translation>打开文件夹失败，您没有该目录的权限！</translation>
     </message>
     <message>
-        <location filename="../../peony-qt-desktop/desktop-icon-view.cpp" line="699"/>
+        <location filename="../../peony-qt-desktop/desktop-icon-view.cpp" line="729"/>
         <source>Open Link failed</source>
         <translation>打开快捷方式失败</translation>
     </message>
     <message>
-        <location filename="../../peony-qt-desktop/desktop-icon-view.cpp" line="700"/>
+        <location filename="../../peony-qt-desktop/desktop-icon-view.cpp" line="730"/>
         <source>File not exist, do you want to delete the link file?</source>
         <translation>目标文件夹不存在，是否删除该无效快捷方式？</translation>
     </message>
@@ -354,9 +354,8 @@
         <translation>桌面</translation>
     </message>
     <message>
-        <location filename="../../peony-qt-desktop/desktop-window.cpp" line="161"/>
         <source>set background</source>
-        <translation>设置壁纸</translation>
+        <translation type="vanished">设置壁纸</translation>
     </message>
     <message>
         <source>New Folder</source>
@@ -370,7 +369,7 @@
         <translation type="vanished">关闭桌面并退出</translation>
     </message>
     <message>
-        <location filename="../../peony-qt-desktop/peony-desktop-application.cpp" line="128"/>
+        <location filename="../../peony-qt-desktop/peony-desktop-application.cpp" line="142"/>
         <source>peony-qt-desktop</source>
         <translation>桌面</translation>
     </message>
@@ -383,19 +382,24 @@
         <translation type="vanished">桌面</translation>
     </message>
     <message>
-        <location filename="../../peony-qt-desktop/peony-desktop-application.cpp" line="251"/>
+        <location filename="../../peony-qt-desktop/peony-desktop-application.cpp" line="244"/>
         <source>Close the peony desktop window</source>
         <translation>关闭桌面程序</translation>
     </message>
     <message>
-        <location filename="../../peony-qt-desktop/peony-desktop-application.cpp" line="254"/>
+        <location filename="../../peony-qt-desktop/peony-desktop-application.cpp" line="247"/>
         <source>Take over the dbus service.</source>
         <translation>接管DBus服务。</translation>
     </message>
     <message>
-        <location filename="../../peony-qt-desktop/peony-desktop-application.cpp" line="257"/>
+        <location filename="../../peony-qt-desktop/peony-desktop-application.cpp" line="250"/>
         <source>Take over the desktop displaying</source>
         <translation>接管桌面</translation>
+    </message>
+    <message>
+        <location filename="../../peony-qt-desktop/peony-desktop-application.cpp" line="340"/>
+        <source>set background</source>
+        <translation>设置壁纸</translation>
     </message>
 </context>
 </TS>


### PR DESCRIPTION
重构桌面：

1、增加对于wayland平台的适配
2、增加virtualDesktopWindow，所有的desktop window都作为它的子窗口进行显示
3、将desktop icon view从desktop window解绑并绑定virtual desktop window，置于顶端（解决桌面图标消失、背景存在的问题）
4、优化与panel位置的交互代码

其它问题：

1、修复gio critical（右键菜单偶发崩溃问题）
2、目前对于wayland适配有一个bug，wayland下弹出菜单有问题，只能在一个屏幕中弹出，无法超过这个屏幕范围，切换主屏问题依旧，暂时没有解决的头绪

review建议：
主要关注屏幕插拔，主屏改变，旋转屏幕，分辨率改变等屏幕操作是否有bug