### PR TITLE
[FIX]  After the first successful FTP login, the address bar is graye…

### DIFF
--- a/libpeony-qt/controls/navigation-bar/location-bar/location-bar.cpp
+++ b/libpeony-qt/controls/navigation-bar/location-bar/location-bar.cpp
@@ -134,14 +134,13 @@ LocationBar::~LocationBar()
 
 void LocationBar::setRootUri(const QString &uri)
 {
-    if (m_current_uri == uri)
-        return;
+//    if (m_current_uri == uri)
+//        return;
 
     m_current_uri = uri;
 
     //clear buttons
     clearButtons();
-
     if (m_current_uri.startsWith("search://")) {
         m_indicator->setArrowType(Qt::NoArrow);
         addButton(m_current_uri, false, false);

--- a/libpeony-qt/file-enumerator.cpp
+++ b/libpeony-qt/file-enumerator.cpp
@@ -185,7 +185,7 @@ const QList<std::shared_ptr<FileInfo>> FileEnumerator::getChildren()
     QList<std::shared_ptr<FileInfo>> children;
     for (auto uri : *m_children_uris) {
         auto file_info = FileInfo::fromUri(uri);
-        children<<file_info;
+        children << file_info;
     }
     return children;
 }

--- a/libpeony-qt/file-info.cpp
+++ b/libpeony-qt/file-info.cpp
@@ -252,8 +252,16 @@ const QString FileInfo::displayName()
     if(!isMountPoint ||                /*@m_uri is like "computer:///xxx"*/
        unixDevice.isEmpty() ||
        !unixDevice.contains("/dev") || /*audio-cd*/
-       unixDevice.contains("/dev/sr")) /*blank-cd or blank-dvd*/
+       unixDevice.contains("/dev/sr")) { /*blank-cd or blank-dvd*/
         return m_display_name;
+    } else if (nullptr != m_uri) {
+        QString uri = m_uri;
+        if (m_uri.endsWith("/") && !m_uri.endsWith(":///") && !m_uri.endsWith("://")) {
+            uri.chop(1);
+        }
+        return uri.split("/").last();
+    }
+
 
     mountDir.setPath(m_uri.mid(7));
     deviceName = m_uri.mid(m_uri.lastIndexOf("/")+1);

--- a/libpeony-qt/model/side-bar-file-system-item.cpp
+++ b/libpeony-qt/model/side-bar-file-system-item.cpp
@@ -37,6 +37,7 @@
 #include <QThread>
 #include <QMessageBox>
 #include <QPushButton>
+#include <QUrl>
 #include <udisks/udisks.h>
 #include <sys/stat.h>
 #include <libnotify/notify.h>
@@ -93,6 +94,7 @@ QString SideBarFileSystemItem::displayName()
     if (!m_unix_device.isEmpty() && !m_uri.contains("root.link")) {
         displayName += QString(" (%1)").arg(m_unix_device);
     }
+
     if (!displayName.isEmpty())
         return displayName;
 

--- a/src/control/tab-widget.cpp
+++ b/src/control/tab-widget.cpp
@@ -960,7 +960,7 @@ void TabWidget::addPage(const QString &uri, bool jumpTo)
 
 void TabWidget::goToUri(const QString &uri, bool addHistory, bool forceUpdate)
 {
-    qDebug() << "goToUri:" <<uri;
+    qDebug() << "goToUri:" << uri;
     currentPage()->goToUri(uri, addHistory, forceUpdate);
     m_tab_bar->updateLocation(m_tab_bar->currentIndex(), uri);
     updateTrashBarVisible(uri);


### PR DESCRIPTION
…d and the FTP TAB will not appear in the left column

[LINK] 21277

BUG编号39999【文件管理器】首次登录ftp成功后，地址栏为灰，左侧栏不会显示ftp页签 