### PR TITLE
[FIX]  When "Send to device" fails, the entire desktop will go black …

### DIFF
--- a/libpeony-qt/convenient-utils/clipboard-utils.cpp
+++ b/libpeony-qt/convenient-utils/clipboard-utils.cpp
@@ -211,7 +211,7 @@ void ClipboardUtils::clearClipboard()
 
 void ClipboardUtils::popLastTargetDirectoryUri(QString &uri)
 {
-    if (uri == m_target_directory_uri.back()) {
+    if (m_target_directory_uri.size() > 0 && uri == m_target_directory_uri.back()) {
         m_target_directory_uri.pop_back();
     }
 }


### PR DESCRIPTION
…for 2 seconds

[LINK] 45762

【右键菜单】“发送到设备”失败后，整个桌面会黑屏2秒
